### PR TITLE
fix: `store.replaceState` could be undefined at init hook

### DIFF
--- a/packages/app-backend/src/hook.js
+++ b/packages/app-backend/src/hook.js
@@ -99,6 +99,10 @@ export function installHook (target) {
   hook.once('vuex:init', store => {
     hook.store = store
     hook.initialState = clone(store.state)
+    // fix store.replaceState cound be undefined
+    if (typeof store.replaceState !== 'function') {
+      store.replaceState = function () {}
+    }
     const origReplaceState = store.replaceState.bind(store)
     store.replaceState = state => {
       hook.initialState = clone(state)


### PR DESCRIPTION
found this issue when visiting https://h5.m.taobao.com/taolive/video.html?id=247286524761&livesource=shop&spm=a2141.7631565.homelive_-1576063041731.0

![image](https://user-images.githubusercontent.com/8336744/70619991-15175200-1c51-11ea-9a10-633dbd702a07.png)
