### PR TITLE
when a data prop contains spaces, surround with quotation marks

### DIFF
--- a/packages/app-frontend/src/components/DataField.vue
+++ b/packages/app-frontend/src/components/DataField.vue
@@ -401,6 +401,10 @@ export default {
       let key = this.field.key
       if (typeof key === 'string') {
         key = key.replace('__vue__', '')
+        // when there's spaces, add quotation marks
+        if (key.indexOf(' ') >= 0) {
+          key = `"${key}"`
+        }
       }
       return key
     }


### PR DESCRIPTION
Taking care of #656 :
When a property has spaces in the name surround it with quotation marks.

_**Example:**_
```
  data () {
    return {
      someArray: [1, 2],
      'someArray ': [2, 3]
    }
  }
```

| before | after |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/7290398/73937728-00b8a400-48e6-11ea-849b-ffa5ed0e3c41.png) | ![image](https://user-images.githubusercontent.com/7290398/73937691-e7175c80-48e5-11ea-9660-da50ffa5aa38.png) |