### PR TITLE
check that we're in a component before rendering a function named _render_

### DIFF
--- a/packages/shared-utils/src/util.js
+++ b/packages/shared-utils/src/util.js
@@ -184,7 +184,7 @@ function replacer (key) {
       return encodeCache.cache(val, () => getCustomRouterDetails(val))
     } else if (val._isVue) {
       return encodeCache.cache(val, () => getCustomInstanceDetails(val))
-    } else if (typeof val.render === 'function') {
+    } else if (typeof val.render === 'function' && getComponentName(val)) {
       return encodeCache.cache(val, () => getCustomComponentDefinitionDetails(val))
     } else if (val.constructor && val.constructor.name === 'VNode') {
       return `[native VNode <${val.tag}>]`


### PR DESCRIPTION
this adresses issue #748.
When a function name is `render` in an array, it's now shown as _Unknown component_.
This is about fixing it.

_**Example:**_
```
  data () {
    return {
      someArray: [1, 2,
        { render: () => 'test' },
        { propfunction: () => 'test' }
      ]
    }
  }
```

| Before | After |
|----|----|
| ![image](https://user-images.githubusercontent.com/7290398/73943687-7aa25a80-48f1-11ea-8ce8-d00fae10b0d6.png) | ![image](https://user-images.githubusercontent.com/7290398/73943617-5a729b80-48f1-11ea-9260-f912daf4c465.png) |
