### PR TITLE
display Map size

### DIFF
--- a/packages/app-frontend/src/filters.js
+++ b/packages/app-frontend/src/filters.js
@@ -52,7 +52,11 @@ export function formattedValue (value, quotes = true) {
   if ((result = specialTokenToString(value))) {
     return result
   } else if (type === 'custom') {
-    return value._custom.display
+    if (value._custom.type === 'map' && value._custom.value) {
+      return `Map[${value._custom.value.length}]`
+    } else {
+      return value._custom.display
+    }
   } else if (type === 'array') {
     return 'Array[' + value.length + ']'
   } else if (type === 'plain-object') {


### PR DESCRIPTION
taking care of issue #750:
Array length was shown, but not Map size.

_**example:**_
```js
  data () {
    return {
      someArray: [1, 2],
      someMap: new Map([[0, 0], [1, 1]])
    }
  }
```

| Before | After |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/7290398/73947387-a294bc80-48f7-11ea-9b05-ef456089b81a.png) | ![image](https://user-images.githubusercontent.com/7290398/73947312-87c24800-48f7-11ea-9b06-6b31ae6815a9.png)  |