### PR TITLE
make select text fit in the window

### DIFF
--- a/packages/app-backend/src/highlighter.js
+++ b/packages/app-backend/src/highlighter.js
@@ -17,6 +17,7 @@ function init () {
   overlay.style.alignItems = 'center'
   overlay.style.justifyContent = 'center'
   overlay.style.borderRadius = '3px'
+  overlay.style.maxWidth = '100vw'
   overlayContent = document.createElement('div')
   overlayContent.style.backgroundColor = 'rgba(104, 182, 255, 0.9)'
   overlayContent.style.fontFamily = 'monospace'


### PR DESCRIPTION
Addressing issue #607.

When a component is larger than the screen,
When using the select tool,
The name can appear outside of the visible screen (since it is centered in the component).

_**example**_:
The simplest example is setting `style="width:300vw"` on a component.

| Before | After |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/7290398/73953847-459e0400-4901-11ea-94e1-963c60cab233.png) | ![image](https://user-images.githubusercontent.com/7290398/73953765-2ef7ad00-4901-11ea-9b8b-e5183fb98b9b.png) |