### PR TITLE
Fix: action icon size

### DIFF
--- a/packages/app-frontend/src/components/ActionHeader.vue
+++ b/packages/app-frontend/src/components/ActionHeader.vue
@@ -35,6 +35,7 @@
     color #ccc
 
 .vue-ui-icon
+  min-width 16px
   width 16px
   height @width
   margin-right 0


### PR DESCRIPTION
When the width of the vue-devtools is not large, the action icons disappear
Example of an error is shown in the screenshot.

![image](https://user-images.githubusercontent.com/24630195/95738788-75708900-0c92-11eb-9418-4610760a402f.png)
