### PR TITLE
fix(types): Add Missing Methods & Props to "./packages/shell-electron/types"

### DIFF
--- a/packages/shell-electron/package.json
+++ b/packages/shell-electron/package.json
@@ -34,6 +34,7 @@
     "@vue-devtools/app-frontend": "^0.0.0",
     "@vue-devtools/build-tools": "^0.0.0",
     "@vue-devtools/shared-utils": "^0.0.0",
+    "vue": "^2.6.12",
     "webpack": "^4.19.0",
     "webpack-cli": "^3.1.0"
   }

--- a/packages/shell-electron/types/index.d.ts
+++ b/packages/shell-electron/types/index.d.ts
@@ -1,9 +1,9 @@
-import type Vue from "vue";
+import type { VueConstructor } from "vue";
 
 interface ConnectOptions {
   io?: Function;
   showToast?: Function;
-  app?: Vue | Vue[];
+  app?: VueConstructor | VueConstructor[];
 }
 
 export function connect(
@@ -12,4 +12,4 @@ export function connect(
   options?: ConnectOptions
 ): void;
 
-export function init(vue: Vue | Vue[]): void;
+export function init(vue: VueConstructor | VueConstructor[]): void;

--- a/packages/shell-electron/types/index.d.ts
+++ b/packages/shell-electron/types/index.d.ts
@@ -9,7 +9,7 @@ interface ConnectOptions {
 export function connect(
   host?: string,
   port?: number | string,
-  options: ConnectOptions
+  options?: ConnectOptions
 ): void;
 
 export function init(vue: Vue | Vue[]): void;

--- a/packages/shell-electron/types/index.d.ts
+++ b/packages/shell-electron/types/index.d.ts
@@ -1,1 +1,15 @@
-export function connect(host?: string, port?: number|string): void
+import type Vue from "vue";
+
+interface ConnectOptions {
+  io?: Function;
+  showToast?: Function;
+  app?: Vue | Vue[];
+}
+
+export function connect(
+  host?: string,
+  port?: number | string,
+  options: ConnectOptions
+): void;
+
+export function init(vue: Vue | Vue[]): void;


### PR DESCRIPTION
Hello,

I noticed that the `init` method exported out of `packages\shell-electron\index.js` was missing from the type file. This pull request fixes that. 

Additionally the type information for the `connect` method was missing the `{ io, showToast, app}` object as an optional prop. This pull request adds it as a parameter named "options", where the option properties are defined in the `ConnectOptions` interface.

You'll also notice that this pull request adds `vue` as a dev dependency so that the `Vue` type can included in the type definitions

## Before
Before this change Typescript show type errors

![image](https://user-images.githubusercontent.com/31548851/113637084-6236e880-9639-11eb-8b41-312c30aa8955.png)
![image](https://user-images.githubusercontent.com/31548851/113637183-9c07ef00-9639-11eb-8310-f18be3e800e5.png)

## After
Typescript errors are gone
![image](https://user-images.githubusercontent.com/31548851/113637322-e38e7b00-9639-11eb-8be6-7d02c5272a70.png)
