### PR TITLE
fix: window is undefined cause an error

### DIFF
--- a/packages/api/src/env.ts
+++ b/packages/api/src/env.ts
@@ -14,7 +14,7 @@ export function getDevtoolsGlobalHook (): any {
 
 export function getTarget (): GlobalTarget {
   // @ts-ignore
-  return typeof navigator !== 'undefined'
+  return (typeof navigator !== 'undefined' && typeof window !== 'undefined')
     ? window
     : typeof global !== 'undefined'
       ? global


### PR DESCRIPTION
`navigator` maybe created by miniapp(or other sth), but `window` still is undefined