### PR TITLE
fix: detect nuxt3

### DIFF
--- a/packages/shell-chrome/src/detector.js
+++ b/packages/shell-chrome/src/detector.js
@@ -16,7 +16,7 @@ function detect (win) {
       let Vue
 
       if (window.$nuxt) {
-        Vue = window.$nuxt.$root.constructor
+        Vue = window.$nuxt.$root && window.$nuxt.$root.constructor
       }
 
       win.postMessage({

--- a/packages/shell-chrome/src/detector.js
+++ b/packages/shell-chrome/src/detector.js
@@ -20,7 +20,8 @@ function detect (win) {
       }
 
       win.postMessage({
-        devtoolsEnabled: Vue && Vue.config.devtools,
+        // TODO disable devtools
+        devtoolsEnabled: !Vue || Vue.config.devtools,
         vueDetected: true,
         nuxtDetected: true
       }, '*')


### PR DESCRIPTION
This PR adds hotfix support for devtools with Nuxt3. Note, devtools will be enabled in production for Nuxt3, just as it seems it is with Vue3, see [these lines](https://github.com/vuejs/vue-devtools/blob/next/packages/shell-chrome/src/detector.js#L31-L41).

This change is necessary for Nuxt3 because:
* `$root.constructor` does not get `Vue` any more in Vue3
* even if we polyfill Vue at `$root.constructor`, `Vue.config.devtools` is not (yet) valid for Vue3