### PR TITLE
docs: Add missing variable declaration

### DIFF
--- a/docs/plugin/plugins-guide.md
+++ b/docs/plugin/plugins-guide.md
@@ -844,6 +844,7 @@ export function setupDevtools (app) {
     // ...
   }, api => {
     api.on.visitComponentTree((payload, context) => {
+      const node = payload.treeNode
       if (payload.componentInstance.type.meow) {
         node.tags.push({
           label: 'meow',


### PR DESCRIPTION
Minor fix- adds a missing declaration. Matches the declarations of `node` that are used elsewhere in the docs.