### PR TITLE
docs: fix edit links

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -11,7 +11,7 @@ module.exports = {
     repo: 'vuejs/vue-devtools',
     logo: '/logo-header.svg',
     docsDir: 'docs',
-    docsBranch: 'next',
+    docsBranch: 'main',
     editLinks: true,
     editLinkText: 'Suggest changes to this page',
 


### PR DESCRIPTION
- 'next' points to non-existent location, 404 error on Github.
- 'main' should be what you're looking for here.