### PR TITLE
fix(vue2): fix async capture errors

### DIFF
--- a/packages/app-backend-vue2/src/components/tree.ts
+++ b/packages/app-backend-vue2/src/components/tree.ts
@@ -175,7 +175,7 @@ async function capture (instance, index?: number, list?: any[]): Promise<Compone
       : instance.componentInstance ? [capture(instance.componentInstance)] : [])
 
     // await all childrenCapture to-be resolved
-    const children = (await Promise.all(childrenPromise)).filter(Boolean)
+    const children = (await Promise.all(childrenPromise)).filter(Boolean) as ComponentTreeNode[]
 
     const treeNode = {
       uid: functionalId,
@@ -194,7 +194,7 @@ async function capture (instance, index?: number, list?: any[]): Promise<Compone
       inactive: false,
       isFragment: false // TODO: Check what is it for.
     }
-    return await api.visitComponentTree(
+    return api.visitComponentTree(
       instance,
       treeNode,
       filter,
@@ -273,7 +273,7 @@ async function capture (instance, index?: number, list?: any[]): Promise<Compone
       backgroundColor: 0xff8344
     })
   }
-  return await api.visitComponentTree(
+  return api.visitComponentTree(
     instance,
     ret,
     filter,


### PR DESCRIPTION
Hi, @Akryum.
I've found that the `async capture` method (packages/app-backend-vue2/src/components/tree.ts)  introduced  last week lead to some cases on Vue 2. 

The Vue2 version of devtools was unable to open the **App** node, report the component structure is illegal:

<img width="586" alt="截屏2021-08-14 下午6 16 26" src="https://user-images.githubusercontent.com/14831358/129442851-d9ea7cc2-02f5-431c-a9c5-67a54021fbcc.png">

When headed towards the devtool's console, it triggers a warning of TypeError of promise not been correctly unwrapped.

<img width="841" alt="截屏2021-08-14 下午6 16 43" src="https://user-images.githubusercontent.com/14831358/129443608-78b46210-69a8-432c-9ee3-e92e980c3ca0.png">


I found that the error is probably caused by the asynchronous calls inside the   `capture` method not been properly handled in order. Hence I've  composed the function calls with `await` keyword, which solved the problem

<img width="588" alt="截屏2021-08-14 下午6 11 19" src="https://user-images.githubusercontent.com/14831358/129443607-362813ff-5c36-4325-ae11-71d442c365d9.png">


