### PR TITLE
fix(vue3): render code crash on transition component

### DIFF
--- a/packages/app-backend-vue3/src/index.ts
+++ b/packages/app-backend-vue3/src/index.ts
@@ -73,7 +73,7 @@ export const backend: DevtoolsBackend = {
     })
 
     api.on.getComponentRenderCode(payload => {
-      payload.code = payload.componentInstance.render.toString()
+      payload.code = !(payload.componentInstance.type instanceof Function) ? payload.componentInstance.render.toString() : payload.componentInstance.type.toString()
     })
 
     api.on.transformCall(payload => {


### PR DESCRIPTION
With reference to #1507 , I found that `Transition` was defined as a functional component in vue 3.x, which caused crash on showing render code. To fix it conditional statement is added.