### PR TITLE
fix(vue3): complete component tree after refreshing

### DIFF
--- a/packages/app-frontend/src/features/components/ComponentsInspector.vue
+++ b/packages/app-frontend/src/features/components/ComponentsInspector.vue
@@ -59,7 +59,7 @@ export default defineComponent({
     // Refresh
 
     function refresh () {
-      requestComponentTree(null)
+      requestComponentTree(selectedComponentId.value)
       loadComponent(selectedComponentId.value)
     }
 


### PR DESCRIPTION
When I select a component with deep nesting and refresh the page, some parts of the component tree is lost.
before:
![refresh1](https://user-images.githubusercontent.com/28253544/133882006-3fd2c6e1-ed8e-4eff-ba13-3268a0421261.PNG)
after refreshing:
![refresh2](https://user-images.githubusercontent.com/28253544/133882013-1bbdff37-b6d4-4985-9326-3557e1a2cb3e.PNG)

So I try to fix it and this might be related to #1367 .