### PR TITLE
feat: UI to copy component names

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
     HTMLDocument: true,
     name: 'off',
     browser: true,
+    NodeJS: true,
   },
   rules: {
     'vue/html-closing-bracket-newline': [

--- a/packages/app-frontend/src/features/components/ComponentTreeNode.vue
+++ b/packages/app-frontend/src/features/components/ComponentTreeNode.vue
@@ -288,30 +288,32 @@ export default defineComponent({
       </span>
 
       <!-- Context menu -->
-      <VueDropdown
-        v-if="selected"
-        :shown="contextMenuOpen"
-        @update:shown="onUpdateShown"
-      >
-        <VueButton
-          slot="trigger"
-          icon-left="more_vert"
-          class="icon-button flat"
-        />
-
-        <div
-          class="context-menu-dropdown"
-          @mouseenter="onContextMenuMouseEnter()"
-          @mouseleave="onContextMenuMouseLeave()"
+      <span class="actions">
+        <VueDropdown
+          v-if="selected"
+          :shown="contextMenuOpen"
+          @update:shown="onUpdateShown"
         >
-          <VueDropdownButton
-            icon-left="flip_to_front"
-            @click="copyComponentName()"
+          <VueButton
+            slot="trigger"
+            icon-left="more_vert"
+            class="icon-button flat"
+          />
+
+          <div
+            class="context-menu-dropdown"
+            @mouseenter="onContextMenuMouseEnter()"
+            @mouseleave="onContextMenuMouseLeave()"
           >
-            {{ $t('DataField.contextMenu.copyComponentName') }}
-          </VueDropdownButton>
-        </div>
-      </VueDropdown>
+            <VueDropdownButton
+              icon-left="flip_to_front"
+              @click="copyComponentName()"
+            >
+              {{ $t('DataField.contextMenu.copyComponentName') }}
+            </VueDropdownButton>
+          </div>
+        </VueDropdown>
+      </span>
     </div>
 
     <div v-if="expanded && instance.children">
@@ -336,8 +338,18 @@ export default defineComponent({
   line-height 10px
   border-radius 3px
 
-.icon-button
-  height 16px
-  width 16px
-  margin-left 10px
+.actions
+  display inline-flex
+  align-items center
+  position relative
+  top -3px
+  left 5px
+  > *
+  .icon-button
+    user-select none
+    width 16px
+    height @width
+    >>> .vue-ui-icon
+      width 16px
+      height @width
 </style>

--- a/packages/app-frontend/src/features/components/ComponentTreeNode.vue
+++ b/packages/app-frontend/src/features/components/ComponentTreeNode.vue
@@ -154,6 +154,10 @@ export default defineComponent({
       }, 4000)
     }
 
+    function onUpdateShown (value) {
+      contextMenuOpen.value = value
+    }
+
     function copyComponentName () {
       copyToClipboard(displayName.value)
     }
@@ -174,7 +178,8 @@ export default defineComponent({
       contextMenuOpen,
       onContextMenuMouseEnter,
       onContextMenuMouseLeave,
-      copyComponentName
+      onUpdateShown,
+      copyComponentName,
     }
   },
 })
@@ -284,8 +289,9 @@ export default defineComponent({
 
       <!-- Context menu -->
       <VueDropdown
-        :open.sync="contextMenuOpen"
         v-if="selected"
+        :shown="contextMenuOpen"
+        @update:shown="onUpdateShown"
       >
         <VueButton
           slot="trigger"
@@ -293,11 +299,11 @@ export default defineComponent({
           class="icon-button flat"
         />
 
-          <div
-            class="context-menu-dropdown"
-            @mouseenter="onContextMenuMouseEnter()"
-            @mouseleave="onContextMenuMouseLeave()"
-          >
+        <div
+          class="context-menu-dropdown"
+          @mouseenter="onContextMenuMouseEnter()"
+          @mouseleave="onContextMenuMouseLeave()"
+        >
           <VueDropdownButton
             icon-left="flip_to_front"
             @click="copyComponentName()"

--- a/packages/app-frontend/src/features/inspector/DataField.vue
+++ b/packages/app-frontend/src/features/inspector/DataField.vue
@@ -624,7 +624,7 @@ export default defineComponent({
         visibility visible
     .icon-button
       user-select none
-      width 20px
+      width 16px
       height @width
     .icon-button >>> .vue-ui-icon,
     .small-icon

--- a/packages/app-frontend/src/features/inspector/DataField.vue
+++ b/packages/app-frontend/src/features/inspector/DataField.vue
@@ -285,6 +285,10 @@ export default defineComponent({
       }, 4000)
     },
 
+    onUpdateShown (value) {
+      this.contextMenuOpen = value
+    },
+
     showMoreSubfields () {
       this.limit += 20
     },
@@ -487,7 +491,8 @@ export default defineComponent({
 
           <!-- Context menu -->
           <VueDropdown
-            :open.sync="contextMenuOpen"
+            :shown="contextMenuOpen"
+            @update:shown="onUpdateShown"
           >
             <VueButton
               slot="trigger"

--- a/packages/app-frontend/src/locales/en.js
+++ b/packages/app-frontend/src/locales/en.js
@@ -38,7 +38,8 @@ export default {
     },
     contextMenu: {
       copyValue: 'Copy Value',
-      copyPath: 'Copy Path'
+      copyPath: 'Copy Path',
+      copyComponentName: 'Copy Component Name'
     },
     quickEdit: {
       number: {

--- a/packages/app-frontend/src/locales/en.js
+++ b/packages/app-frontend/src/locales/en.js
@@ -39,7 +39,7 @@ export default {
     contextMenu: {
       copyValue: 'Copy Value',
       copyPath: 'Copy Path',
-      copyComponentName: 'Copy Component Name'
+      copyComponentName: 'Copy Component Name',
     },
     quickEdit: {
       number: {


### PR DESCRIPTION
According to #1555 , I added UI button so that it can copy the component name, which is referred to the state data operation like this:

<img width="250" alt="1342342" src="https://user-images.githubusercontent.com/28253544/138054558-16e30ea5-3826-4ac1-80d5-c74b9a13931a.png">


Thank you for your code review. The style could be optimized. And also I noticed the issue #1351  mentioned that we would like to add UI to filter out components. That can be added below the button list I think.
