### PR TITLE
refactor: node_modules/vuex/dist/vuex.esm-bundler.js import { setupDe…

### DIFF
--- a/packages/api/src/proxy.ts
+++ b/packages/api/src/proxy.ts
@@ -36,7 +36,7 @@ export class ApiProxy<TTarget extends DevtoolsPluginApi<any> = DevtoolsPluginApi
       }
     }
     const localSettingsSaveId = `__vue-devtools-plugin-settings__${plugin.id}`
-    let currentSettings = { ...defaultSettings }
+    let currentSettings = Object.assign({}, defaultSettings)
     try {
       const raw = localStorage.getItem(localSettingsSaveId)
       const data = JSON.parse(raw)


### PR DESCRIPTION
…vtoolsPlugin } from '@vue/devtools-api';

          The production model is packaged into the vendor.
          The proxy that vue 3 relies on supports at least Chrome 49, Spread syntax in object literals supports at least Chrome 60.