### PR TITLE
fix: empty `$vnode.data`

### DIFF
--- a/packages/app-backend-vue2/src/components/tree.ts
+++ b/packages/app-backend-vue2/src/components/tree.ts
@@ -275,7 +275,7 @@ async function capture (instance, index?: number, list?: any[]): Promise<Compone
   ret.consoleId = consoleId > -1 ? '$vm' + consoleId : null
 
   // check router view
-  const isRouterView2 = instance.$vnode && instance.$vnode.data.routerView
+  const isRouterView2 = instance.$vnode && instance.$vnode.data && instance.$vnode.data.routerView
   if (instance._routerView || isRouterView2) {
     ret.isRouterView = true
     if (!instance._inactive && instance.$route) {


### PR DESCRIPTION
Fix the issue #1433 

Reproduction repo - https://github.com/ItMaga/vue-devtools-bug

This is incorrect behavior `vuedraggable` library, but i think devtools should continue to work correctly 