### PR TITLE
fix(plugin): early proxy `hook` can be `undefined`

### DIFF
--- a/packages/api/src/proxy.ts
+++ b/packages/api/src/proxy.ts
@@ -59,11 +59,13 @@ export class ApiProxy<TTarget extends DevtoolsPluginApi<any> = DevtoolsPluginApi
       },
     }
 
-    hook?.on(HOOK_PLUGIN_SETTINGS_SET, (pluginId, value) => {
-      if (pluginId === this.plugin.id) {
-        this.fallbacks.setSettings(value)
-      }
-    })
+    if (hook) {
+      hook.on(HOOK_PLUGIN_SETTINGS_SET, (pluginId, value) => {
+        if (pluginId === this.plugin.id) {
+          this.fallbacks.setSettings(value)
+        }
+      })
+    }
 
     this.proxiedOn = new Proxy({} as Hookable<Context>, {
       get: (_target, prop: string) => {

--- a/packages/api/src/proxy.ts
+++ b/packages/api/src/proxy.ts
@@ -59,7 +59,7 @@ export class ApiProxy<TTarget extends DevtoolsPluginApi<any> = DevtoolsPluginApi
       },
     }
 
-    hook.on(HOOK_PLUGIN_SETTINGS_SET, (pluginId, value) => {
+    hook?.on(HOOK_PLUGIN_SETTINGS_SET, (pluginId, value) => {
       if (pluginId === this.plugin.id) {
         this.fallbacks.setSettings(value)
       }


### PR DESCRIPTION
Fix #1616 