### PR TITLE
refactor: inherit inactive state

### DIFF
--- a/packages/api/src/api/component.ts
+++ b/packages/api/src/api/component.ts
@@ -12,6 +12,7 @@ export interface ComponentTreeNode {
   isFragment: boolean
   hasChildren: boolean
   children: ComponentTreeNode[]
+  cache?: ComponentTreeNode[]
   domOrder?: number[]
   consoleId?: string
   isRouterView?: boolean

--- a/packages/app-frontend/src/features/components/ComponentTreeNode.vue
+++ b/packages/app-frontend/src/features/components/ComponentTreeNode.vue
@@ -31,7 +31,9 @@ export default defineComponent({
     const componentHasKey = computed(() => (props.instance.renderKey === 0 || !!props.instance.renderKey) && props.instance.renderKey !== UNDEFINED)
 
     const sortedChildren = computed<ComponentTreeNode[]>(() => props.instance.children
-      ? sortChildren(props.instance.children)
+      ? props.instance.cache
+        ? sortChildren([...props.instance.children, ...props.instance.cache])
+        : sortChildren(props.instance.children)
       : [])
 
     const {
@@ -265,7 +267,7 @@ export default defineComponent({
       <ComponentTreeNode
         v-for="(child, index) in sortedChildren"
         :key="child.id"
-        :instance="child"
+        :instance="instance.inactive ? { ...child, inactive: instance.inactive } : child"
         :depth="depth + 1"
         @select-next-sibling="selectNextSibling(index)"
         @select-previous-sibling="selectPreviousSibling(index)"


### PR DESCRIPTION
Previously, the cached components were pushed into `treeNode.children` and they replaced the active components, which caused #1615 . So I added `cache` to `ComponentTreeNode` to fix it. At the same time I removed some recursions to improve performance.