### PR TITLE
fix: display injection of 'symbol' key

### DIFF
--- a/packages/shell-dev-vue3/src/Provide.vue
+++ b/packages/shell-dev-vue3/src/Provide.vue
@@ -5,6 +5,9 @@
 <script>
 import { provide, inject } from 'vue'
 
+const symbolForInject = Symbol('inject')
+const symbolForSetup = Symbol('setup')
+
 export default {
   components: {
     Inject: {
@@ -22,10 +25,11 @@ export default {
           template: '<div>nested inject: {{ renamed }} missing: {{ missing }}</div>',
         },
       },
-      inject: ['injectedData'],
+      inject: ['injectedData', symbolForInject],
       setup () {
         return {
           comingFromSetup: inject('fromSetup'),
+          comingFromSymbol: inject(symbolForSetup),
         }
       },
       template: '<div>injected: {{ injectedData }} | {{ comingFromSetup }}<NestedInject /></div>',
@@ -35,11 +39,13 @@ export default {
   provide () {
     return {
       injectedData: 'bar',
+      [symbolForInject]: 'foo',
     }
   },
 
   setup () {
     provide('fromSetup', 'Setup!!')
+    provide(symbolForSetup, 'Symbol from Setup')
   },
 }
 </script>


### PR DESCRIPTION
Fixes and closes #1643 .

I also make it support default value, for example change the test component `Provide` of devtools to:

```js
inject: {
  i: {from: 'injectedta', default: 'wrong key name'}, 
  [Symbol('alias')]: symbolForProvided
},
```
Then on the devtools panel showed: 
![image](https://user-images.githubusercontent.com/28253544/147740771-b9d06ffe-0733-4571-ae92-7e1bf8476675.png)
