### PR TITLE
fix: avoid exception when opening devtools on a non-vue page

### DIFF
--- a/packages/shell-chrome/src/devtools-background.js
+++ b/packages/shell-chrome/src/devtools-background.js
@@ -16,7 +16,7 @@ function createPanelIfHasVue () {
     return
   }
   chrome.devtools.inspectedWindow.eval(
-    '!!(window.__VUE_DEVTOOLS_GLOBAL_HOOK__.Vue || window.__VUE_DEVTOOLS_GLOBAL_HOOK__.apps.length)',
+    '!!(window.__VUE_DEVTOOLS_GLOBAL_HOOK__ && (window.__VUE_DEVTOOLS_GLOBAL_HOOK__.Vue || window.__VUE_DEVTOOLS_GLOBAL_HOOK__.apps.length))',
     function (hasVue) {
       if (!hasVue || created) {
         return


### PR DESCRIPTION
Solves the following error when opening browser devtools on a non-vue page

```
TypeError: can't access property "Vue", window.__VUE_DEVTOOLS_GLOBAL_HOOK__ is undefined
```