### PR TITLE
fix: Add object entries polyfill for app-backend-vue2

### DIFF
--- a/packages/app-backend-vue2/package.json
+++ b/packages/app-backend-vue2/package.json
@@ -10,14 +10,15 @@
     "ts": "tsc -d -outDir lib"
   },
   "dependencies": {
-    "@vue/devtools-api": "^6.0.0-beta.7",
     "@vue-devtools/app-backend-api": "^0.0.0",
     "@vue-devtools/shared-utils": "^0.0.0",
+    "@vue/devtools-api": "^6.0.0-beta.7",
     "clone-deep": "^4.0.1"
   },
   "devDependencies": {
     "@types/node": "^13.9.1",
     "@types/webpack-env": "^1.15.1",
+    "core-js": "^3.20.2",
     "typescript": "^4.5.2"
   }
 }

--- a/packages/app-backend-vue2/src/components/data.ts
+++ b/packages/app-backend-vue2/src/components/data.ts
@@ -1,6 +1,7 @@
 import { camelize, getComponentName, getCustomRefDetails, StateEditor, SharedData } from '@vue-devtools/shared-utils'
 import { ComponentState, HookPayloads, Hooks, InspectedComponentData } from '@vue/devtools-api'
 import { functionalVnodeMap, instanceMap } from './tree'
+import 'core-js/modules/es.object.entries'
 
 /**
  * Get the detailed information of an inspected instance.

--- a/yarn.lock
+++ b/yarn.lock
@@ -4110,6 +4110,11 @@ core-js-compat@^3.18.0, core-js-compat@^3.19.1:
     browserslist "^4.17.6"
     semver "7.0.0"
 
+core-js@^3.20.2:
+  version "3.20.2"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.20.2.tgz#46468d8601eafc8b266bd2dd6bf9dee622779581"
+  integrity sha512-nuqhq11DcOAbFBV4zCbKeGbKQsUDRqTX0oqx7AttUBuqe3h20ixsE039QHelbL6P4h+9kytVqyEtyZ6gsiwEYw==
+
 core-js@^3.6.4:
   version "3.19.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.19.1.tgz#f6f173cae23e73a7d88fa23b6e9da329276c6641"
@@ -4243,7 +4248,7 @@ csstype@^2.6.8:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.19.tgz#feeb5aae89020bb389e1f63669a5ed490e391caa"
   integrity sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==
 
-cypress@=3.4.1, cypress@^3.1.0:
+cypress@^3.1.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-3.4.1.tgz#ca2e4e9864679da686c6a6189603efd409664c30"
   integrity sha512-1HBS7t9XXzkt6QHbwfirWYty8vzxNMawGj1yI+Fu6C3/VZJ8UtUngMW6layqwYZzLTZV8tiDpdCNBypn78V4Dg==
@@ -11301,7 +11306,7 @@ webpack-dev-middleware@^5.0.0:
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
 
-webpack-dev-server@=4.0.0-rc.0, webpack-dev-server@^4.0.0-beta.0:
+webpack-dev-server@^4.0.0-beta.0:
   version "4.0.0-rc.0"
   resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.0.0-rc.0.tgz#56099f1e1e877d15a1fc28a928f38bbc600e33da"
   integrity sha512-9S+MywBN/ecr8AbXNVUnmbFji8UTtzLR6M5Dgy6sB5Ti/73UgHn8TMhLaSBZBkY/cmSmWHDSwUXFs8lOeARpOw==


### PR DESCRIPTION
Fixes https://github.com/vuejs/devtools/issues/949 by adding the specific polyfill from core-js. It'd be nice if @dacotagh validates it.