### PR TITLE
fix: generated app id not deduped

### DIFF
--- a/packages/app-backend-core/src/app.ts
+++ b/packages/app-backend-core/src/app.ts
@@ -139,7 +139,7 @@ export function getAppRecordId (app, defaultId?: string): string {
 
   if (defaultId && appIds.has(id)) {
     let count = 1
-    while (appIds.has(`${defaultId}:${count}`)) {
+    while (appIds.has(`${defaultId}_${count}`)) {
       count++
     }
     id = `${defaultId}_${count}`


### PR DESCRIPTION
This fixes a bug where more than two components with the same name could not be held apart by the backend. It is looking for `defaultId:count`while counting references but then names the reference `defaultId_count` this resulted in a maximum of two components with the same name being recognized (that is clickable) in the devtools.