### PR TITLE
fix(electron): enable CORS for socket.io server (fix #1813)

### DIFF
--- a/packages/shell-electron/server.js
+++ b/packages/shell-electron/server.js
@@ -7,7 +7,11 @@ const { Server } = require('socket.io')
 const port = process.env.PORT || 8098
 
 const httpServer = createServer(app)
-const io = new Server(httpServer, {})
+const io = new Server(httpServer, {
+  cors: {
+    origin: true,
+  },
+})
 
 app.get('/', function (req, res) {
   const hookContent = fs.readFileSync(path.join(__dirname, '/build/hook.js'), 'utf8')


### PR DESCRIPTION
close #1813

<!-- Thank you for contributing! -->

### Description

Added the cors origin config to socket.io server.

### Additional context

#### Socket.IO - Migrating from 2.x to 3.0 - CORS handling
https://socket.io/docs/v4/migrating-from-2-x-to-3-0/#cors-handling

#### CORS - Configuration Options
https://github.com/expressjs/cors#configuration-options

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [X] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->
