### PR TITLE
fix: typo in title of welcome slideshow

### DIFF
--- a/packages/app-frontend/src/features/welcome/WelcomeSlideshow.vue
+++ b/packages/app-frontend/src/features/welcome/WelcomeSlideshow.vue
@@ -42,7 +42,7 @@ export default defineComponent({
         </template>
 
         <template v-if="step === 1">
-          <h2>Let's have little tour</h2>
+          <h2>Let's take a little tour</h2>
 
           <p>
             The devtools were entirely rewritten with the release of Vue 3.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Thank you for all your hard work on the awesome devtools!

This is a minor edit to fix a typo in the title of the welcome slide show. This is missing an "a" before "little tour". Also, I would say it's more common (in American English, at least) to say "take a tour" vs. "have a tour", though they may both be correct.

### Additional context

n/a

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [x] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ x Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->
