### PR TITLE
feat: add components mousein highlight event throttle

### DIFF
--- a/packages/app-frontend/src/features/components/composable/highlight.ts
+++ b/packages/app-frontend/src/features/components/composable/highlight.ts
@@ -2,7 +2,7 @@ import { useBridge } from '@front/features/bridge'
 import { BridgeEvents } from '@vue-devtools/shared-utils'
 import { Ref } from '@vue/composition-api'
 
-function handleThrottle (duration = 200) {
+function createThrottleFn (duration = 200) {
   let timer: ReturnType<typeof setTimeout> | undefined
   let isExecuting = false
 
@@ -32,7 +32,7 @@ function handleThrottle (duration = 200) {
   return exec
 }
 
-const execThrottleFn = handleThrottle()
+const execThrottleFn = createThrottleFn()
 
 export function useComponentHighlight (id: Ref<string>) {
   const { bridge } = useBridge()

--- a/packages/app-frontend/src/features/components/composable/highlight.ts
+++ b/packages/app-frontend/src/features/components/composable/highlight.ts
@@ -2,15 +2,47 @@ import { useBridge } from '@front/features/bridge'
 import { BridgeEvents } from '@vue-devtools/shared-utils'
 import { Ref } from '@vue/composition-api'
 
+function handleThrottle (duration = 200) {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  let isExecuting = false
+
+  const clear = () => {
+    if (timer) {
+      clearTimeout(timer)
+      timer = undefined
+    }
+  }
+
+  function exec (fn) {
+    if (isExecuting) {
+      clear()
+      timer = setTimeout(() => {
+        isExecuting = true
+        fn()
+      }, duration)
+    } else {
+      timer = setTimeout(() => {
+        isExecuting = false
+      }, duration)
+      fn()
+    }
+    isExecuting = true
+  }
+
+  return exec
+}
+
+const execThrottleFn = handleThrottle()
+
 export function useComponentHighlight (id: Ref<string>) {
   const { bridge } = useBridge()
 
   function highlight () {
-    bridge.send(BridgeEvents.TO_BACK_COMPONENT_MOUSE_OVER, id.value)
+    execThrottleFn(() => bridge.send(BridgeEvents.TO_BACK_COMPONENT_MOUSE_OVER, id.value))
   }
 
   function unhighlight () {
-    bridge.send(BridgeEvents.TO_BACK_COMPONENT_MOUSE_OUT)
+    execThrottleFn(() => bridge.send(BridgeEvents.TO_BACK_COMPONENT_MOUSE_OUT))
   }
 
   return {


### PR DESCRIPTION
### Description

when the mouse over the component tree will trigger hight events frequently，if the compenent tree is big or deep，it would make UI slow and doesn't response.

### Additional context

add components mouse-in highlight event throttle，this problem fixed.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [x] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).