### PR TITLE
fix: AppMainMenu: use compact layout if screen is narrow

### DIFF
--- a/packages/app-frontend/src/features/header/AppHeader.vue
+++ b/packages/app-frontend/src/features/header/AppHeader.vue
@@ -104,7 +104,7 @@ export default defineComponent({
 
     <AppMainMenu
       :last-inspector-route="lastInspectorRoute"
-      :label-shown="!showAppsSelector"
+      :label-shown="!showAppsSelector && inspectorRoutes.length * 200 < $responsive.width - 420"
     />
 
     <template v-if="currentInspectorRoute">


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

in a small screen width, the buttons to select an element, refresh and settings, do not fit due to the fact that the inspector and timeline buttons have a label

before: 
![before](https://user-images.githubusercontent.com/63998986/192100084-6e920b38-3e8f-47d3-aa5a-b2e6d762cb95.png)
after:
![after](https://user-images.githubusercontent.com/63998986/192100103-65b03392-5ce6-40c3-a0ad-42e5da73cbc8.png)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I think that it can be done better, but I just corrected what bothered me

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other

### Before submitting the PR, please make sure you do the following

- [X ] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [ X] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [X ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->