### PR TITLE
feat(components): handle hotkeys by event.code

### DIFF
--- a/packages/app-frontend/src/features/components/ComponentsInspector.vue
+++ b/packages/app-frontend/src/features/components/ComponentsInspector.vue
@@ -42,16 +42,16 @@ export default defineComponent({
     } = useComponentPick()
 
     onKeyDown(event => {
-      if (event.key === 'f' && event.altKey) {
+      if (event.code === 'KeyF' && event.altKey) {
         treeFilterInput.value.focus()
         return false
-      } else if (event.key === 's' && event.altKey && !pickingComponent.value) {
+      } else if (event.code === 'KeyS' && event.altKey && !pickingComponent.value) {
         startPickingComponent()
         return false
       } else if (event.key === 'Escape' && pickingComponent.value) {
         stopPickingComponent()
         return false
-      } else if (event.key === 'r' && (event.ctrlKey || event.metaKey) && event.altKey) {
+      } else if (event.code === 'KeyR' && (event.ctrlKey || event.metaKey) && event.altKey) {
         refresh()
         return false
       }

--- a/packages/app-frontend/src/features/components/SelectedComponentPane.vue
+++ b/packages/app-frontend/src/features/components/SelectedComponentPane.vue
@@ -33,7 +33,7 @@ export default defineComponent({
     // State filter
     const stateFilterInput = ref()
     onKeyDown(event => {
-      if (event.key === 'd' && event.altKey) {
+      if (event.code === 'KeyD' && event.altKey) {
         stateFilterInput.value.focus()
         return false
       }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
In the current version hotkeys that use English letters (alt+f, alt+s, alt+d, ctrl+alt+r) are handled by event.key, which makes it impossible to use them in other language keyboard layouts.
Handling keys with event.code fixes this problem.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [X] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->
