### PR TITLE
feat(component): Add support for better naming of `/index.vue` components

### DIFF
--- a/packages/app-backend-vue3/src/components/util.ts
+++ b/packages/app-backend-vue3/src/components/util.ts
@@ -1,5 +1,4 @@
-import { classify } from '@vue-devtools/shared-utils'
-import { basename } from '../util'
+import { classify, basename } from '@vue-devtools/shared-utils'
 import { ComponentInstance, App } from '@vue/devtools-api'
 import { BackendContext } from '@vue-devtools/app-backend-api'
 

--- a/packages/app-backend-vue3/src/util.ts
+++ b/packages/app-backend-vue3/src/util.ts
@@ -9,15 +9,6 @@ export function flatten (items) {
   }, [])
 }
 
-// Use a custom basename functions instead of the shimed version
-// because it doesn't work on Windows
-export function basename (filename, ext) {
-  return path.basename(
-    filename.replace(/^[a-zA-Z]:/, '').replace(/\\/g, '/'),
-    ext,
-  )
-}
-
 export function returnError (cb: () => any) {
   try {
     return cb()

--- a/packages/shared-utils/src/util.ts
+++ b/packages/shared-utils/src/util.ts
@@ -331,9 +331,13 @@ export function reviveSet (val) {
 
 // Use a custom basename functions instead of the shimed version
 // because it doesn't work on Windows
-function basename (filename, ext) {
+export function basename (filename, ext) {
+  filename = filename.replace(/\\/g, '/')
+  if (filename.includes(`/index${ext}`)) {
+    filename = filename.replace(`/index${ext}`, ext)
+  }
   return path.basename(
-    filename.replace(/^[a-zA-Z]:/, '').replace(/\\/g, '/'),
+    filename.replace(/^[a-zA-Z]:/, ''),
     ext,
   )
 }

--- a/packages/shell-dev-vue3/src/App.vue
+++ b/packages/shell-dev-vue3/src/App.vue
@@ -21,6 +21,7 @@ import SetupScript from './SetupScript.vue'
 import SetupDataLike from './SetupDataLike.vue'
 import SetupTSScriptProps from './SetupTSScriptProps.vue'
 import DomOrder from './DomOrder.vue'
+import IndexComponent from './IndexComponent/index.vue'
 
 import { h, createApp } from 'vue'
 import SimplePlugin from './devtools-plugin/simple'
@@ -51,6 +52,7 @@ export default {
     SetupDataLike,
     SetupTSScriptProps,
     DomOrder,
+    IndexComponent,
     inline: {
       render: () => h('h3', 'Inline component definition'),
     },
@@ -114,6 +116,7 @@ export default {
   </div>
 
   <Child question="Life" />
+  <IndexComponent />
   <NestedMore />
   <NativeTypes ref="nativeTypes" />
   <EventEmit />

--- a/packages/shell-dev-vue3/src/IndexComponent/index.vue
+++ b/packages/shell-dev-vue3/src/IndexComponent/index.vue
@@ -1,0 +1,3 @@
+<template>
+  <h2>Index component</h2>
+</template>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR relates to https://github.com/vuejs/devtools/issues/387. Sometimes developers have components nested inside directories and follow classic Node approach of naming them `/index.${extenstion}`, in this case `/index.vue`. Devtools currently display every component as `<Index>` unless you specify `name`. This PR will check for those components and use parent directory as component name.

#### Example

Compnent is defined in `src/IndexComponent/index.vue`

Before:

![Screenshot 2022-11-26 at 12 08 48](https://user-images.githubusercontent.com/389286/204085690-6f5aef22-c41c-4bbf-88ee-7a6ec88f3b16.png)

After:

![Screenshot 2022-11-26 at 12 08 08](https://user-images.githubusercontent.com/389286/204085691-9d58177b-a464-4041-89e7-9357245c1f50.png)

### Additional context

I’ve also taken the chance to use `basename` function from `@vue/shared-utils` and removed same command form Vue 3 backend namespace.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [x] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->
