### PR TITLE
fix: Better check if data name starts with use (fix: #1971)

### DIFF
--- a/packages/app-backend-vue3/src/components/data.ts
+++ b/packages/app-backend-vue3/src/components/data.ts
@@ -177,7 +177,7 @@ function processState (instance) {
 function processSetupState (instance) {
   const raw = instance.devtoolsRawSetupState || {}
   return Object.keys(instance.setupState)
-    .filter(key => !vueBuiltins.includes(key) && !key.startsWith('use'))
+    .filter(key => !vueBuiltins.includes(key) && key.split(/(?=[A-Z])/)[0] !== 'use')
     .map(key => {
       const value = returnError(() => toRaw(instance.setupState[key]))
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Previously check was only a `startsWith()` leading to not displaying names like `userXXX`. With this regex, we check if the first part of our string before another uppercase starts with `use`.

Fixing issue #1971 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [x] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->
