### PR TITLE
fix(chrome): stop extension unloading in Firefox, fix #1974

### DIFF
--- a/packages/shell-chrome/manifest.json
+++ b/packages/shell-chrome/manifest.json
@@ -28,7 +28,7 @@
     "scripts": [
       "build/background.js"
     ],
-    "persistent": false
+    "persistent": true
   },
   "permissions": [
     "<all_urls>",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Firefox starting with version 106 introduced a change which apparently broke background pages. For the Vuejs devtools, this surfaced as extension unloading when the browser reached an "idle" state. User having the extension open noticed it as a unloading/reloading of the devtools tab.

By setting background.persisted to true in the manifest.json, the unloading stopped.

Note: This is a temporary solution, until Manifest v3 is properly supported.

### Additional context

#1974 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [x] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->
