### PR TITLE
fix(vue3): ensure 3rd party components directly imported in script setup do not show up as `Anonymous Component` in devtools

### DIFF
--- a/packages/app-backend-vue3/src/components/util.ts
+++ b/packages/app-backend-vue3/src/components/util.ts
@@ -45,7 +45,7 @@ function saveComponentName (instance, key) {
 }
 
 function getComponentTypeName (options) {
-  const name = options.name || options._componentTag || options.__vdevtools_guessedName
+  const name = options.name || options.__name || options._componentTag || options.__vdevtools_guessedName
   if (name) {
     return name
   }

--- a/packages/app-backend-vue3/src/components/util.ts
+++ b/packages/app-backend-vue3/src/components/util.ts
@@ -45,7 +45,7 @@ function saveComponentName (instance, key) {
 }
 
 function getComponentTypeName (options) {
-  const name = options.name || options.__name || options._componentTag || options.__vdevtools_guessedName
+  const name = options.name || options._componentTag || options.__vdevtools_guessedName || options.__name
   if (name) {
     return name
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

When we import and use  a 3rd Party component in `<script setup>` like in the following example, it will show up as `<Anonymous Component>` in devtools.

```html

<script setup>
import Child from 'cool-ui-library'
</script>
<template>
   <Child />
</template
```

This PR makes devtools fall back on the internal `__name` property added by `@vitejs/plugin-vue` (this name is derrived from the filename) if no explicit name has been set.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I'm not sure how to add a test case for this. But I hope the fix is trivial enough to do without one.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [ x Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->
