### PR TITLE
fix: disable devtool avoid chrome csp

### DIFF
--- a/packages/shell-electron/webpack.config.js
+++ b/packages/shell-electron/webpack.config.js
@@ -19,4 +19,7 @@ module.exports = createConfig({
     publicPath: '/build/',
     filename: '[name].js',
   },
+  devtool: process.env.NODE_ENV !== 'production'
+    ? 'inline-source-map'
+    : false,
 }, target)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When I use vue writing a chrome extension's popup page, the vue-devtool's client inject code can't work normally since it using `eval` function which is not allowed in chrome extension V3 manifest.

So I modify the shell-electron's client code webpack build config reference from shell-chrome package's build config, make it would not includes `eval` in dist code.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [ ] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->
