### PR TITLE
fix(vue3): Optimize the priority of calculating the displayed name of the component on the devtool

### DIFF
--- a/packages/app-backend-vue3/src/components/util.ts
+++ b/packages/app-backend-vue3/src/components/util.ts
@@ -36,6 +36,10 @@ export function getInstanceName (instance) {
   for (const key in instance.appContext?.components) {
     if (instance.appContext.components[key] === instance.type) return saveComponentName(instance, key)
   }
+  const fileName = getComponentFileName(instance.type || {})
+  if (fileName) {
+    return fileName
+  }
   return 'Anonymous Component'
 }
 
@@ -45,10 +49,10 @@ function saveComponentName (instance, key) {
 }
 
 function getComponentTypeName (options) {
-  const name = options.name || options._componentTag || options.__vdevtools_guessedName || options.__name
-  if (name) {
-    return name
-  }
+  return options.name || options._componentTag || options.__vdevtools_guessedName || options.__name
+}
+
+function getComponentFileName (options) {
   const file = options.__file // injected by vue-loader
   if (file) {
     return classify(basename(file, '.vue'))


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Description
fix: #2049
Optimize the priority of calculating the displayed name of the component on the devtool.

The registered name should have a higher display priority than the file name (the detail is in the issue).

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [x] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->
