### PR TITLE
fix(vue3): Fix the declared camelCase event cannot be recognized

### DIFF
--- a/packages/app-backend-vue3/src/components/data.ts
+++ b/packages/app-backend-vue3/src/components/data.ts
@@ -1,6 +1,6 @@
 import { BackendContext } from '@vue-devtools/app-backend-api'
 import { getInstanceName, getUniqueComponentId } from './util'
-import { camelize, StateEditor, SharedData } from '@vue-devtools/shared-utils'
+import { camelize, StateEditor, SharedData, kebabize } from '@vue-devtools/shared-utils'
 import { ComponentInstance, CustomState, HookPayloads, Hooks, InspectedComponentData } from '@vue/devtools-api'
 import { returnError } from '../util'
 
@@ -371,13 +371,14 @@ function processRefs (instance) {
 function processEventListeners (instance) {
   const emitsDefinition = instance.type.emits
   const declaredEmits = Array.isArray(emitsDefinition) ? emitsDefinition : Object.keys(emitsDefinition ?? {})
+  const normalizedDeclaredEmits = declaredEmits.map(key => kebabize(key))
   const keys = Object.keys(instance.vnode.props ?? {})
   const result = []
   for (const key of keys) {
     const [prefix, ...eventNameParts] = key.split(/(?=[A-Z])/)
     if (prefix === 'on') {
       const eventName = eventNameParts.join('-').toLowerCase()
-      const isDeclared = declaredEmits.includes(eventName)
+      const isDeclared = normalizedDeclaredEmits.includes(eventName)
       result.push({
         type: 'event listeners',
         key: eventName,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix: #2046 
fix: #2063
fix: #2060

Fix the declared camelCase event that cannot be recognized.

the declaredEmits are not normalized to kebab case, which results in the mismatching with the declared events on the parent component side.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [x] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->
