### PR TITLE
fix(electron): chunk message data

### DIFF
--- a/packages/shared-utils/src/util.ts
+++ b/packages/shared-utils/src/util.ts
@@ -769,3 +769,23 @@ export function copyToClipboard (state) {
 export function isEmptyObject (obj) {
   return obj === UNDEFINED || !obj || Object.keys(obj).length === 0
 }
+
+/**
+ * chunk an array into smaller chunk of given size.
+ * @see https://stackoverflow.com/a/37826698
+ * @param array
+ * @param size
+ */
+export function chunk (array: unknown[], size: number): unknown[][] {
+  return array.reduce((resultArray, item, index) => {
+    const chunkIndex = Math.floor(index / size)
+
+    if (!resultArray[chunkIndex]) {
+      resultArray[chunkIndex] = [] // start a new chunk
+    }
+
+    resultArray[chunkIndex].push(item)
+
+    return resultArray
+  }, []) as unknown[][]
+}

--- a/packages/shell-electron/src/backend.js
+++ b/packages/shell-electron/src/backend.js
@@ -1,13 +1,14 @@
 import io from 'socket.io-client'
 import { initBackend } from '@back'
 import { installToast } from '@back/toast'
-import { Bridge, target } from '@vue-devtools/shared-utils'
+import { Bridge, target, chunk } from '@vue-devtools/shared-utils'
 
 const host = target.__VUE_DEVTOOLS_HOST__ || 'http://localhost'
 const port = target.__VUE_DEVTOOLS_PORT__ !== undefined ? target.__VUE_DEVTOOLS_PORT__ : 8098
 const fullHost = port ? host + ':' + port : host
 const createSocket = target.__VUE_DEVTOOLS_SOCKET__ || io
 const socket = createSocket(fullHost)
+const MAX_DATA_CHUNK = 2000
 
 const connectedMessage = () => {
   if (target.__VUE_DEVTOOLS_TOAST__) {
@@ -45,7 +46,11 @@ const bridge = new Bridge({
     socket.on('vue-message', data => fn(data))
   },
   send (data) {
-    socket.emit('vue-message', data)
+    const chunks = chunk(data, MAX_DATA_CHUNK)
+
+    for (const chunk of chunks) {
+      socket.emit('vue-message', chunk)
+    }
   },
 })
 


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Description

Added chunking to bridge `send` function, in the electron shell backend, to prevent crash when sending very large payload.
Added chunk function, in utils, based on [Andrei R](https://stackoverflow.com/a/37826698) answer on stackoverflow.

### Additional context

Socket.io's [size limit is 1 mb](https://socket.io/fr/how-to/upload-a-file#maxhttpbuffersize-limit). When sending a payload larger than that, the socket connection would hang up on it's own and the devtools would be disconnected.

This PR could potentially fix many crashing issue when working with large projects. Some related issues are:
- #1386
- #1252
- #1287

However, this fix is only applied on the standalone electron app. This is why I am not referencing this PR as a direct fix for those issues.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [x] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->
