### PR TITLE
Update package.json for install Cypress

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "webpack-dev-server": "^4.0.0-beta.0"
   },
   "resolutions": {
-    "cypress": "=3.4.1",
+    "cypress": "=12.10.0",
     "webpack-dev-server": "=4.0.0-rc.0"
   },
   "engines": {


### PR DESCRIPTION
The original cypress version reported an error Downloading Cypress [failed] when yarn install, and it can only be compiled normally after the updated version.