### PR TITLE
fix: Always updated the inspected component even if the updated hook is not triggered.

### DIFF
--- a/packages/app-backend-core/src/index.ts
+++ b/packages/app-backend-core/src/index.ts
@@ -121,8 +121,8 @@ async function connect () {
   const sendComponentUpdate = throttle(async (appRecord: AppRecord, id: string) => {
     try {
       // Update component inspector
-      if (id && isSubscribed(BridgeSubscriptions.SELECTED_COMPONENT_DATA, sub => sub.payload.instanceId === id)) {
-        await sendSelectedComponentData(appRecord, id, ctx)
+      if (ctx.currentInspectedComponentId) {
+        await sendSelectedComponentData(appRecord, ctx.currentInspectedComponentId, ctx)
       }
 
       // Update tree (tags)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix: #2064, #2045

As described in #2064, the inspected component won't be updated if the "updated" hook is not triggered, which in some cases that the internal status of the component is not accurate.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [x] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->
