### PR TITLE
fix(timeline): incorrect unit for group duration (fix issue #1837)

### DIFF
--- a/packages/app-frontend/src/features/timeline/TimelineEventInspector.vue
+++ b/packages/app-frontend/src/features/timeline/TimelineEventInspector.vue
@@ -121,7 +121,7 @@ export default defineComponent({
             duration: {
               _custom: {
                 value: inspectedEvent.group.duration,
-                display: `${inspectedEvent.group.duration} ms`
+                display: `${inspectedEvent.group.duration / 1000} ms`
               }
             }
           }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I fixed bug #1837 which highlighted the value expressed in ms 1000 times higher than the reality.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [x] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->
