### PR TITLE
fix(backend): ensure currentAppRecord is defined when backend handli…

### DIFF
--- a/packages/app-backend-core/src/app.ts
+++ b/packages/app-backend-core/src/app.ts
@@ -97,15 +97,15 @@ async function createAppRecord (options: AppRecordOptions, backend: DevtoolsBack
       appRecord: mapAppRecord(record),
     })
 
+    // Auto select first app
+    if (ctx.currentAppRecord == null) {
+      await selectApp(record, ctx)
+    }
+
     if (appRecordPromises.has(options.app)) {
       for (const r of appRecordPromises.get(options.app)) {
         await r(record)
       }
-    }
-
-    // Auto select first app
-    if (ctx.currentAppRecord == null) {
-      await selectApp(record, ctx)
     }
   } else if (SharedData.debugInfo) {
     console.warn('[Vue devtools] No root instance found for app, it might have been unmounted', options.app)


### PR DESCRIPTION
…ng components events emitted from Vue. (fix #1770)

<!-- Thank you for contributing! -->

### Description

I have noticed that there are some issues caused by the reason that `currentAppRecord` is not defined (but it is used when some hooks such as `COMPONENT_ADDED` are called). Typical issues are #1770 and #1711. And there is [good case analysis](https://github.com/vuejs/devtools/issues/1711#issuecomment-1441915959).

I had same issue when I developed a Micro Frontends project which contains both Vue2 and Vue3 app instance. And I found that [`selectApp function`](https://github.com/vuejs/devtools/blob/122207de2ed79d839c572438b095ce3f5ea1fed9/packages/app-backend-core/src/app.ts#L115) is almost a synchronous function. So I just change the order of code execution in [`createAppRecord function`](https://github.com/vuejs/devtools/blob/122207de2ed79d839c572438b095ce3f5ea1fed9/packages/app-backend-core/src/app.ts#L53) then errors disappeared.

@yyx990803 吐槽一下，这个二十几k星项目的文档还有很大的提升空间。

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [X] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->
