### PR TITLE
fix(component): filtering components of third-party libraries to script(other)

### DIFF
--- a/packages/app-backend-vue3/src/components/data.ts
+++ b/packages/app-backend-vue3/src/components/data.ts
@@ -188,7 +188,8 @@ function processSetupState (instance) {
 
       let isOther = typeof value === 'function' ||
         typeof value?.render === 'function' ||
-        typeof value?.__asyncLoader === 'function'
+        typeof value?.__asyncLoader === 'function' ||
+        typeof value === 'object' && ('setup' in value || 'props' in value)
 
       if (rawData) {
         const info = getSetupStateInfo(rawData)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Problem: if you use third-party ui libraries, the instance of the used components gets into the "setup" block and is mixed with the instance of your component, which is very annoying.
<img width="1362" alt="bad" src="https://github.com/vuejs/devtools/assets/63998986/055a6dfd-880b-4319-97c1-ca7165ca9dc4">


Solution: Added check for component and redirect components to "script(other)" block
<img width="1362" alt="good" src="https://github.com/vuejs/devtools/assets/63998986/a4510d74-e2c8-4848-9f34-b002585a97c7">


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [x] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->
