### PR TITLE
fix(vue3): Show the imported component setup state by using exposed in production

### DIFF
--- a/packages/app-backend-vue3/src/components/data.ts
+++ b/packages/app-backend-vue3/src/components/data.ts
@@ -176,11 +176,16 @@ function processState (instance) {
 }
 
 function processSetupState (instance) {
-  const raw = instance.devtoolsRawSetupState || {}
-  return Object.keys(instance.setupState)
+  const raw = instance.devtoolsRawSetupState
+  const combinedSetupState = (Object.keys(instance.setupState).length
+    ? instance.setupState
+    : instance.exposed
+  ) || {}
+
+  return Object.keys(combinedSetupState)
     .filter(key => !vueBuiltins.includes(key) && key.split(/(?=[A-Z])/)[0] !== 'use')
     .map(key => {
-      const value = returnError(() => toRaw(instance.setupState[key]))
+      const value = returnError(() => toRaw(combinedSetupState[key]))
 
       const rawData = raw[key]
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix: #2061

### Additional context

As the reason: https://github.com/vuejs/core/issues/4866#issuecomment-1128313856

The `setupState` is not exposed in production mode, so we cannot inspect the internal state of built library described in #2061 

Inspired by https://github.com/vuejs/core/issues/8515#issuecomment-1581906384, we can use `exposed` field to inspect the state.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [x] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->
