### PR TITLE
ci: Fix broken CircleCI build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
       # specify the version you desire here
       - image: node:current
       - image: vuejs/ci
+    resource_class: medium+
 
     working_directory: ~/repo
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

It seems like due to the limitation of memory of the container, CI always fails. After trying to change the container to a bigger one (medium+), it succeeds.

Reproduction on my job: https://app.circleci.com/pipelines/github/Azurewarth0920/devtools/1/workflows/a5f8b619-6d0f-42ad-9586-61d282f7c65b/jobs/1


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [x] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->
