### PR TITLE
fix(vue2): Remove throwing error on inspect missing vuex module

### DIFF
--- a/packages/app-backend-vue2/src/plugin.ts
+++ b/packages/app-backend-vue2/src/plugin.ts
@@ -117,6 +117,9 @@ export function setupPlugin (api: DevtoolsApi, app: App, Vue) {
         if (payload.inspectorId === VUEX_INSPECTOR_ID) {
           const modulePath = payload.nodeId
           const module = getStoreModule(store._modules, modulePath)
+          if (!module) {
+            return
+          }
           // Access the getters prop to init getters cache (which is lazy)
           // eslint-disable-next-line no-unused-expressions
           module.context.getters
@@ -496,10 +499,8 @@ function getStoreModule (moduleMap, path) {
   const names = path.split(VUEX_MODULE_PATH_SEPARATOR).filter((n) => n)
   return names.reduce(
     (module, moduleName, i) => {
-      const child = module[moduleName === VUEX_ROOT_PATH ? 'root' : moduleName]
-      if (!child) {
-        throw new Error(`Missing module "${moduleName}" for path "${path}".`)
-      }
+      const child = module ? module[moduleName === VUEX_ROOT_PATH ? 'root' : moduleName] : null
+      if (!child) return null
       return i === names.length - 1 ? child : child._children
     },
     path === VUEX_ROOT_PATH ? moduleMap : moduleMap.root._children,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix: #1669

Refs: https://github.com/vuejs/devtools/issues/1669#issuecomment-1678899513
As commented above, "Save focused element path in localStorage" → "Revive focusing on refresh page" will easily result in throwing error, I think somehow missing a module is normal behavior, throwing the error is not necessary.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [x] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->
