### PR TITLE
fix(timeline): Reset layer status when selected layer is hidden in timeline

### DIFF
--- a/packages/app-frontend/src/features/timeline/TimelineEventList.vue
+++ b/packages/app-frontend/src/features/timeline/TimelineEventList.vue
@@ -144,9 +144,8 @@ export default defineComponent({
     // Auto bottom scroll
 
     function scrollToBottom () {
-      if (!scroller.value) return
-
       requestAnimationFrame(() => {
+        if (!scroller.value) return
         const scrollerEl = scroller.value.$el
         scrollerEl.scrollTop = scrollerEl.scrollHeight
       })

--- a/packages/app-frontend/src/features/timeline/composable/layers.ts
+++ b/packages/app-frontend/src/features/timeline/composable/layers.ts
@@ -68,9 +68,22 @@ export function useLayers () {
     return list.includes(layer.id)
   }
 
+  function resetSelectedStatus () {
+    selectedLayer.value = null
+    inspectedEvent.value = null
+    selectedEvent.value = null
+    hoverLayerId.value = null
+    setStorage('selected-layer-id', '')
+  }
+
   function setLayerHidden (layer: Layer, hidden: boolean) {
     const list = getHiddenLayers(currentAppId.value)
     const index = list.indexOf(layer.id)
+
+    if (selectedLayer.value === layer) {
+      resetSelectedStatus()
+    }
+
     if (hidden && index === -1) {
       list.push(layer.id)
     } else if (!hidden && index !== -1) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix: #2108

Hiding a selected layer will cause many errors on hovering other layers, and will break the timeline when refreshing the page.

Reset layer status when hiding the selected layer will eliminate this error.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [x] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->
