### PR TITLE
fix: mac hotkeys (fix #1907)

### DIFF
--- a/packages/app-frontend/src/features/components/ComponentsInspector.vue
+++ b/packages/app-frontend/src/features/components/ComponentsInspector.vue
@@ -42,16 +42,17 @@ export default defineComponent({
     } = useComponentPick()
 
     onKeyDown(event => {
-      if (event.key === 'f' && event.altKey) {
+      // ƒ,ß,® - these are the result keys in Mac with altKey pressed
+      if ((event.key === 'f' || event.key === 'ƒ') && event.altKey) {
         treeFilterInput.value.focus()
         return false
-      } else if (event.key === 's' && event.altKey && !pickingComponent.value) {
+      } else if ((event.key === 's' || event.key === 'ß') && event.altKey && !pickingComponent.value) {
         startPickingComponent()
         return false
       } else if (event.key === 'Escape' && pickingComponent.value) {
         stopPickingComponent()
         return false
-      } else if (event.key === 'r' && (event.ctrlKey || event.metaKey) && event.altKey) {
+      } else if ((event.key === 'r' || event.key === '®') && (event.ctrlKey || event.metaKey) && event.altKey) {
         refresh()
         return false
       }

--- a/packages/app-frontend/src/features/components/SelectedComponentPane.vue
+++ b/packages/app-frontend/src/features/components/SelectedComponentPane.vue
@@ -33,7 +33,8 @@ export default defineComponent({
     // State filter
     const stateFilterInput = ref()
     onKeyDown(event => {
-      if (event.key === 'd' && event.altKey) {
+      // ∂ - the result key in Mac with altKey pressed
+      if ((event.key === 'd' || event.key === '∂') && event.altKey) {
         stateFilterInput.value.focus()
         return false
       }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

PR about hotkeys from here
![image](https://github.com/vuejs/devtools/assets/41228762/1cac1b0b-50d6-48a5-8384-2f477c832768)

On Mac "option" key modifies the resulted `event.key` value (`s` becomes `ß`) that's why check `event.key === 's'` doesn't work.
According to [mdn's KeyboardEvent: code article](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code) we can't fix the bug with `event.code === 'KeyS'` because on different keyboard layouts symbol will be different.
```
For example, the code returned is "KeyQ" for the Q key on a QWERTY layout keyboard,
but the same code value also represents the ' key on Dvorak keyboards and the A key
on AZERTY keyboards. 

That makes it impossible to use the value of code to determine what the name of the 
key is to users if they're not using an anticipated keyboard layout.
```

So I just added the resulting keys to the whitelist.

### Additional context

There is another old PR but with a different fix
https://github.com/vuejs/devtools/pull/1993

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [x] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->
