### PR TITLE
fix:  parse overlay safeArea safely

### DIFF
--- a/packages/overlay/src/composables/position.ts
+++ b/packages/overlay/src/composables/position.ts
@@ -1,7 +1,7 @@
 import { computed, onMounted, reactive, ref, watchEffect } from 'vue'
 import type { CSSProperties, Ref } from 'vue'
 import { useEventListener, useScreenSafeArea } from '@vueuse/core'
-import { clamp } from '../utils'
+import { clamp, pixelToNumber } from '../utils'
 import { useFrameState } from './state'
 
 function snapToPoints(value: number) {
@@ -34,10 +34,10 @@ export function usePosition(panelEl: Ref<HTMLElement | undefined>) {
   const safeArea = useScreenSafeArea()
 
   watchEffect(() => {
-    panelMargins.left = +safeArea.left.value + 10
-    panelMargins.top = +safeArea.top.value + 10
-    panelMargins.right = +safeArea.right.value + 10
-    panelMargins.bottom = +safeArea.bottom.value + 10
+    panelMargins.left = pixelToNumber(safeArea.left.value) + 10
+    panelMargins.top = pixelToNumber(safeArea.top.value) + 10
+    panelMargins.right = pixelToNumber(safeArea.right.value) + 10
+    panelMargins.bottom = pixelToNumber(safeArea.bottom.value) + 10
   })
 
   const onPointerDown = (e: PointerEvent) => {

--- a/packages/overlay/src/utils/index.ts
+++ b/packages/overlay/src/utils/index.ts
@@ -3,3 +3,9 @@ export function clamp(value: number, min: number, max: number) {
 }
 
 export const checkIsSafari = () => navigator.userAgent.includes('Safari') && !navigator.userAgent.includes('Chrome')
+
+export function pixelToNumber(value: string | number) {
+  if (typeof value === 'string')
+    return value.endsWith('px') ? +value.slice(0, -2) : +value
+  return value
+}


### PR DESCRIPTION
the `safeArea` will sometimes be two different values, like `""` or `"0px"`

<img width="614" alt="image" src="https://github.com/webfansplz/vue-devtools-next/assets/49969959/e748004b-80bb-4cbe-91de-358b9f90713f">

So we should parse the value safely, otherwise, a bug will occur, like this:


https://github.com/webfansplz/vue-devtools-next/assets/49969959/36b9a3ea-31eb-4c41-aeb4-03e4246bad63

