### PR TITLE
fix: add null checks for appRecord and appRecord.instanceMap, fix #1892

### DIFF
--- a/packages/app-backend-core/src/index.ts
+++ b/packages/app-backend-core/src/index.ts
@@ -250,7 +250,10 @@ async function connect () {
       if (isSubscribed(BridgeSubscriptions.SELECTED_COMPONENT_DATA, sub => sub.payload.instanceId === id)) {
         await sendEmptyComponentData(id, ctx)
       }
-      appRecord.instanceMap.delete(id)
+
+      if (appRecord) {
+        appRecord.instanceMap.delete(id)
+      }
 
       await refreshComponentTreeSearch(ctx)
     } catch (e) {

--- a/packages/app-backend-core/src/perf.ts
+++ b/packages/app-backend-core/src/perf.ts
@@ -17,6 +17,7 @@ export async function performanceMarkStart (
   try {
     if (!SharedData.performanceMonitoringEnabled) return
     const appRecord = await getAppRecord(app, ctx)
+    if (!appRecord) return
     const componentName = await appRecord.backend.api.getComponentName(instance)
     const groupId = ctx.perfUniqueGroupId++
     const groupKey = `${uid}-${type}`
@@ -80,6 +81,7 @@ export async function performanceMarkEnd (
   try {
     if (!SharedData.performanceMonitoringEnabled) return
     const appRecord = await getAppRecord(app, ctx)
+    if (!appRecord) return
     const componentName = await appRecord.backend.api.getComponentName(instance)
     const groupKey = `${uid}-${type}`
     const groupInfo = appRecord.perfGroupIds.get(groupKey)

--- a/packages/app-backend-core/src/plugin.ts
+++ b/packages/app-backend-core/src/plugin.ts
@@ -14,6 +14,7 @@ export async function addPlugin (pluginQueueItem: PluginQueueItem, ctx: BackendC
   ctx.currentPlugin = plugin
   try {
     const appRecord = await getAppRecord(plugin.descriptor.app, ctx)
+    if (!appRecord) return
     const api = new DevtoolsPluginApiInstance(plugin, appRecord, ctx)
     if (pluginQueueItem.proxy) {
       await pluginQueueItem.proxy.setRealTarget(api)

--- a/packages/app-backend-core/src/timeline.ts
+++ b/packages/app-backend-core/src/timeline.ts
@@ -73,6 +73,7 @@ function setupBuiltinLayers (ctx: BackendContext) {
       if (!SharedData.componentEventsEnabled) return
 
       const appRecord = await getAppRecord(app, ctx)
+      if (!appRecord) return
       const componentId = `${appRecord.id}:${instance.uid}`
       const componentDisplay = (await appRecord.backend.api.getComponentName(instance)) || '<i>Unknown Component</i>'
 


### PR DESCRIPTION
fix(index.ts): add null checks for appRecord and appRecord.instanceMap to prevent errors when accessing properties

<!-- Thank you for contributing! -->

### Description

Fixes #1892 

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [x] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
