### PR TITLE
fix: chrome crashing on closing dev tools (fix #2103)

### DIFF
--- a/packages/shell-chrome/src/backend.js
+++ b/packages/shell-chrome/src/backend.js
@@ -49,7 +49,7 @@ function handshake(e) {
 
     initBackend(bridge)
   }
-  else {
+  else if (e.data.source !== 'vue-devtools-backend-injection') {
     sendListening()
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #2103
When closing devtools, an infinite loop is triggered by the line:
https://github.com/vuejs/devtools/blob/963ff7fe1470aa5b2a93a8a8afadc57fa3c38676/packages/shell-chrome/src/backend.js#L47

This may be due to a Chrome bug - after closing devtools, the `window.postMessage` call in `backend.js` triggers the event listener in the same file, and as the reaction to a message is to postMessage back, an infinite loop is triggered this way.

### Additional context

To the best of my knowledge:
- this should not happen, and is likely a Chromium issue
- this only happens when devtools are closed (the logic that filters out self from the triggers for `window.on('message')` breaks down only in this case)
- `packages/shell-chrome/src/backend.js` is the only file where a `window.postMessage` is triggered as a fallback on a `window.on('message')` listener, so no other places have this issue

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [x] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->
