### PR TITLE
Fix Vue 2.7 + composition API error

### DIFF
--- a/packages/app-backend-vue2/src/components/data.ts
+++ b/packages/app-backend-vue2/src/components/data.ts
@@ -499,7 +499,7 @@ export function editState(
     && Object.keys(componentInstance._setupState).includes(path[0])
   ) {
     // setup
-    target = componentInstance._setupProxy
+    target = componentInstance._setupProxy || componentInstance
 
     const currentValue = stateEditor.get(target, path)
     if (currentValue != null) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Following the pattern of https://github.com/vuejs/devtools/commit/e38c3472ef047163ae99d9a3d2f65563a2d2fd2c, this should allow dev tools reaching vue properly on multiple function calls, eg. `editComponentState`

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [x] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->
