### PR TITLE
docs: use Algolia search API key

### DIFF
--- a/packages/docs/src/.vitepress/config.js
+++ b/packages/docs/src/.vitepress/config.js
@@ -19,7 +19,7 @@ export default defineConfig({
 
     algolia: {
       appId: 'CFRGFZ1IGJ',
-      apiKey: '6c814da38002372317bcbefd73e60bbf',
+      apiKey: 'cf7b3ddb7b310746c27c1a71ff7d4fe2',
       indexName: 'devtools-vuejs',
     },
 


### PR DESCRIPTION
### Description

(reported by @yyx990803 ) the key used in the docs atm is the crawler api key, meaning it have more rights than just searching the index (crud records, delete index etc.), so I've rotated it in order to fix the crawler, and generated a search only one for your docs

I'll wait for this PR to be merged to delete the current key, so your search still works in the meantime

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [x] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->
