### PR TITLE
docs: change installation documentation for more consistent package manager usage.

### DIFF
--- a/packages/docs/src/guide/installation.md
+++ b/packages/docs/src/guide/installation.md
@@ -150,9 +150,9 @@ Or if you want to debug your device remotely:
 Then start your development server like you are used to, *without* killing the `vue-devtools` command (for example, open a new terminal). Both need to run in parallel.
 
 ```bash
-yarn dev
+npm run dev
 #or
-yarn serve
+npm run serve
 ```
 
 ### Using dependency package


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The documentation showed `npm` being used to install the tool, but then `yarn` to run a server. This changes the examples to all use `npm` for consistency's sake. Alternatively, you could switch all code blocks to `yarn`, or add example code for each package manager.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://devtools.vuejs.org/guide/contributing.html).
- [X] Read the [Pull Request Guidelines](https://devtools.vuejs.org/guide/contributing.html#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vuejs/devtools/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
<!-- @TODO tests - [ ] Ideally, include relevant tests that fail without this PR but pass with it. -->
