### PR TITLE
fix: revert devtools-kit removals in #664

### DIFF
--- a/packages/devtools-kit/src/ctx/hook.ts
+++ b/packages/devtools-kit/src/ctx/hook.ts
@@ -248,7 +248,7 @@ export function createDevToolsCtxHooks() {
     const _payload = {
       app: plugin.descriptor.app,
       inspectorId,
-      filter: inspector?.treeFilterPlaceholder || '',
+      filter: inspector?.treeFilter || '',
       rootNodes: [],
     }
 

--- a/packages/devtools-kit/src/ctx/inspector.ts
+++ b/packages/devtools-kit/src/ctx/inspector.ts
@@ -13,6 +13,7 @@ interface DevToolsKitInspector {
   descriptor: PluginDescriptor
   treeFilterPlaceholder: string
   stateFilterPlaceholder: string
+  treeFilter: string
   selectedNodeId: string
   appRecord: unknown
 }
@@ -34,6 +35,7 @@ export function addInspector(inspector: CustomInspectorOptions, descriptor: Plug
     descriptor,
     treeFilterPlaceholder: inspector.treeFilterPlaceholder ?? 'Search tree...',
     stateFilterPlaceholder: inspector.stateFilterPlaceholder ?? 'Search state...',
+    treeFilter: '',
     selectedNodeId: '',
     appRecord: getAppRecord(descriptor.app),
   })


### PR DESCRIPTION
This is a hotfix to #664, the PR removes some state on devtools-kit which will causes some feature crash.

Closes #669 