### PR TITLE
feat: refine bg/text color for dark mode

### DIFF
--- a/packages/applet/uno.config.ts
+++ b/packages/applet/uno.config.ts
@@ -38,8 +38,8 @@ export default defineConfig(mergeConfigs([unoConfig, {
   ],
   shortcuts: [{
     // general
-    'bg-base': 'bg-white dark:bg-black',
-    'text-base': 'text-black dark:text-white',
+    'bg-base': 'bg-white dark:bg-#212427',
+    'text-base': 'text-black dark:text-#dfe0e2',
     'bg-active': 'bg-gray:5',
     'border-base': 'border-gray/20',
     'transition-base': 'transition-all duration-200',

--- a/packages/client/uno.config.ts
+++ b/packages/client/uno.config.ts
@@ -51,8 +51,8 @@ export default defineConfig(mergeConfigs([unoConfig, {
   ],
   shortcuts: [{
     // general
-    'bg-base': 'bg-white dark:bg-[#121212]',
-    'text-base': 'text-black dark:text-white',
+    'bg-base': 'bg-white dark:bg-#212427',
+    'text-base': 'text-black dark:text-#dfe0e2',
     'bg-active': 'bg-gray:5',
     'border-base': 'border-gray/20',
     'navbar-base': 'border-b border-base h-50px',

--- a/packages/ui/theme/uno.config.ts
+++ b/packages/ui/theme/uno.config.ts
@@ -44,14 +44,14 @@ export const unoConfig = {
     '$ui-z-max-override': 'z-2147483647',
 
     // general
-    '$ui-bg-base': 'bg-white dark:bg-black',
+    '$ui-bg-base': 'bg-white dark:bg-#212427',
     '$ui-base': 'box-border font-inherit',
     '$ui-transition': 'transition-all duration-300 ease-in-out',
     '$ui-borderless': '!border-transparent !shadow-none',
     '$ui-base-br': 'rounded-3px',
     '$ui-border-base': 'border-gray/20',
-    '$ui-text': 'text-black dark:text-white',
-    '$ui-glass-effect': 'backdrop-blur-6 bg-white/80 dark:bg-black/90',
+    '$ui-text': 'text-black dark:text-#dfe0e2',
+    '$ui-glass-effect': 'backdrop-blur-6 bg-white/80 dark:bg-#3C3C3C/90',
   },
   rules: [
     ['$ui-font-inherit', { 'font-family': 'inherit' }],


### PR DESCRIPTION
Before:
<img width="1748" alt="image" src="https://github.com/user-attachments/assets/1c08a5b4-ea39-4d41-990d-ae5c9a0dc73c">


Now:
<img width="1805" alt="image" src="https://github.com/user-attachments/assets/d168cd08-e44c-489b-8f35-6ae135f15ff6">

I just updated background/text color for dark mode to reduce eye strain, especially on darker pages. 

I’d appreciate any feedback!