### PR TITLE
fix(vite): add configured headers for devtool-related response

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -95,6 +95,15 @@ export default function VitePluginVueDevTools(options?: VitePluginVueDevToolsOpt
     server.middlewares.use(`${base}__devtools__`, sirv(DIR_CLIENT, {
       single: true,
       dev: true,
+      setHeaders(response) {
+        if (config.server.headers == null)
+          return
+        Object.entries(config.server.headers).forEach(([key, value]) => {
+          if (value == null)
+            return
+          response.setHeader(key, value)
+        })
+      },
     }))
 
     // vite client <-> server messaging


### PR DESCRIPTION
`server.headers` in vite configuration is now ignored by `__devtool__` related requests, which are handled by `sirv`.

This PR applies `server.headers` in vite configuration to these requests' response.

This PR fixes #565.