### PR TITLE
Update standalone.md

### DIFF
--- a/docs/guide/standalone.md
+++ b/docs/guide/standalone.md
@@ -98,7 +98,7 @@ You can also use the global `vue-devtools` to start the app, but you might want 
 Then import it directly in your app:
 
 ```ts
-import { devtools } from '@vue/devtools'
+import { devtools } from '@vue/devtools-kit'
 ```
 
 And connect to host:


### PR DESCRIPTION
There is no '@vue/devtools' in my 'node_modules' folder so I had to change this to '@vue/devtools-kit' in order to make it work.