### PR TITLE
chore(vite): remove newline on server urls

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -119,7 +119,7 @@ export default function VitePluginVueDevTools(options?: VitePluginVueDevToolsOpt
         const devtoolsUrl = url.endsWith('/') ? `${url}__devtools__/` : `${url}/__devtools__/`
         console.log(`  ${green('➜')}  ${bold('Vue DevTools')}: ${green(`Open ${colorUrl(`${devtoolsUrl}`)} as a separate window`)}`)
       }
-      console.log(`  ${green('➜')}  ${bold('Vue DevTools')}: ${green(`Press ${yellow(keys)} in App to toggle the Vue DevTools`)}\n`)
+      console.log(`  ${green('➜')}  ${bold('Vue DevTools')}: ${green(`Press ${yellow(keys)} in App to toggle the Vue DevTools`)}`)
     }
   }
 


### PR DESCRIPTION
While working on https://github.com/unocss/unocss/pull/4361 (which takes great inspiration from Vue Devtools, thanks!), I noticed that there is a newline character that introduces trailing between the console output of any other Vite plugin. We seem to assume that Vue Devtools is the only plugin that will print to the console, however that might not always be true (as seen in the linked's PR screenshot).

Though the issue this PR is tackling is a nitpick, I believe it's better to no show any space at all between the help commands rather than force all plugins to have `enforce: 'pre'` or mess up with the "styling" of the console output.