### PR TITLE
fix(api): allow treeshaking

### DIFF
--- a/packages/devtools-api/package.json
+++ b/packages/devtools-api/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@vue/devtools-api",
   "type": "module",
+  "sideEffects": false,
   "version": "7.7.1",
   "author": "webfansplz",
   "license": "MIT",


### PR DESCRIPTION
Currently, the api isn't tree shaken when building.

Closes https://github.com/vuejs/pinia/issues/2910

This can be reproduced with https://github.com/vuejs/pinia/tree/v3/packages/size-check. In v6, this was added at https://unpkg.com/browse/@vue/devtools-api@6.6.4/package.json