### PR TITLE
chore: update test case to align with vue behavior

### DIFF
--- a/packages/devtools-kit/__tests__/component/decode-state.test.ts
+++ b/packages/devtools-kit/__tests__/component/decode-state.test.ts
@@ -1,3 +1,5 @@
+import { getObjectDetails } from '../../src/core/component/state/custom'
+
 function omitKeysOnCustom(obj: { _custom: { [key: string]: unknown } } | undefined, keys: string[]) {
   return obj == null ? obj : { _custom: Object.fromEntries(Object.entries(obj._custom).filter(([key]) => !keys.includes(key))) }
 }
@@ -68,6 +70,7 @@ it.each([
     () => {
       const bar = computed(() => '1')
       const a = toRef(() => bar.value)
+      a.value
       return a
     },
     {
@@ -83,6 +86,7 @@ it.each([
     () => {
       const bar = reactive({ value: '1' })
       const a = toRef(bar, 'value')
+      a.value
       return a
     },
     {
@@ -98,6 +102,7 @@ it.each([
     () => {
       const bar = reactive({ value: '1', value2: '2' })
       const a = toRefs(bar)
+      a.value.value
       return a.value
     },
     {
@@ -109,5 +114,5 @@ it.each([
     },
   ],
 ])('should getObjectDetail by passing %s state', (_, state, expected) => {
-  // expect(omitKeysOnCustom(getObjectDetails(state()), ['tooltipText'])).toEqual(expected)
+  expect(omitKeysOnCustom(getObjectDetails(state()), ['tooltipText'])).toEqual(expected)
 })

--- a/packages/devtools-kit/src/core/component/state/custom.ts
+++ b/packages/devtools-kit/src/core/component/state/custom.ts
@@ -219,8 +219,8 @@ export function getHTMLElementDetails(value: HTMLElement) {
 }
 
 /**
- * - ObjectRefImpl, toRef({ foo: 'foo' }, 'foo'), `value` is the actual value
- * - GetterRefImpl, toRef(() => state.foo), `value` is the actual value
+ * - ObjectRefImpl, toRef({ foo: 'foo' }, 'foo'), `_value` is the actual value, (since 3.5.0)
+ * - GetterRefImpl, toRef(() => state.foo), `_value` is the actual value, (since 3.5.0)
  * - RefImpl, ref('foo') / computed(() => 'foo'), `_value` is the actual value
  */
 function tryGetRefValue(ref: { _value?: unknown } | { value?: unknown }) {


### PR DESCRIPTION
since https://github.com/vuejs/core/pull/11539, customRefs's value has cached, so we should access the value first.

see the logic of getObjectDetails

```ts
// ...
const value = toRaw(info.reactive ? object : tryGetRefValue(object))

/**
 * - ObjectRefImpl, toRef({ foo: 'foo' }, 'foo'), `_value` is the actual value, (since 3.5.0)
 * - GetterRefImpl, toRef(() => state.foo), `_value` is the actual value, (since 3.5.0)
 * - RefImpl, ref('foo') / computed(() => 'foo'), `_value` is the actual value
 */
function tryGetRefValue(ref: { _value?: unknown } | { value?: unknown }) {
  if (ensurePropertyExists<{ _value?: unknown }>(ref, '_value', true)) {
    return ref._value
  }
  if (ensurePropertyExists(ref, 'value', true)) {
    return ref.value
  }
}
```