### PR TITLE
fix: resolve `Map` nested object modification

### DIFF
--- a/packages/devtools-kit/__tests__/component/editor.test.ts
+++ b/packages/devtools-kit/__tests__/component/editor.test.ts
@@ -176,5 +176,20 @@ describe('editor: StateEditor.set', () => {
       stateEditor.set(target, path, '', defaultCallback)
       expect(target).toEqual(new Map([['bar', 'baz']]))
     })
+
+    it('modify nested value in map', () => {
+      const target = { foo: new Map([['bar', {
+        baz: 1,
+      }]]) }
+      const state = { newKey: '', type: '', value: 2 }
+      const path = ['foo', 'bar', 'baz']
+      const defaultCallback = stateEditor.createDefaultSetCallback(state)
+      stateEditor.set(target, path, 2, defaultCallback)
+      expect(target).toEqual({
+        foo: new Map([['bar', {
+          baz: 2,
+        }]]),
+      })
+    })
   })
 })

--- a/packages/devtools-kit/src/core/component/state/editor.ts
+++ b/packages/devtools-kit/src/core/component/state/editor.ts
@@ -23,7 +23,7 @@ export class StateEditor {
       const section = sections.shift()!
       if (object instanceof Map)
         object = object.get(section) as Recordable
-      if (object instanceof Set)
+      else if (object instanceof Set)
         object = Array.from(object.values())[section] as Recordable
       else object = object[section] as Recordable
       if (this.refEditor.isRef(object))


### PR DESCRIPTION
Currently, modifying a nested object in a Map in Pinia causes an error.
![image](https://github.com/user-attachments/assets/54b88b73-3ee9-4794-8e0c-e563c95c1d67)
![image](https://github.com/user-attachments/assets/8ad3ba17-30d4-4378-bb3a-e204dd269600)

This PR contains a fix for that issue and a new test.