### PR TITLE
chore: add `onlyBuiltDependencies` list

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,16 @@
     "vitest": "^3.0.6",
     "vue": "^3.5.13"
   },
+  "pnpm": {
+    "ignoredBuiltDependencies": [
+      "core-js"
+    ],
+    "onlyBuiltDependencies": [
+      "electron",
+      "esbuild",
+      "vue-demi"
+    ]
+  },
   "simple-git-hooks": {
     "pre-commit": "pnpm lint-staged"
   },


### PR DESCRIPTION
After pnpm 10 lifecycle scripts of dependencies are not executed during installation by default!  https://github.com/pnpm/pnpm/releases/tag/v10.0.0