### PR TITLE
feat: add onLoad and onClose to iframe custom tab

### DIFF
--- a/packages/client/src/components/CustomTabComponent.vue
+++ b/packages/client/src/components/CustomTabComponent.vue
@@ -34,7 +34,7 @@ watch(() => tabName.value, () => {
     </div>
   </template>
   <template v-else-if="tab?.view?.type === 'iframe'">
-    <IframeView v-if="iframeViewVisible" :src="tab.view.src" :inline="iframeInline" />
+    <IframeView v-if="iframeViewVisible" :src="tab.view.src" :inline="iframeInline" @load="tab.view.onLoad" @close="tab.view.onClose" />
   </template>
   <template v-else-if="tab?.view?.type === 'vnode'">
     <Component :is="tab.view.vnode" />

--- a/packages/client/src/components/common/IframeView.vue
+++ b/packages/client/src/components/common/IframeView.vue
@@ -8,6 +8,8 @@ const iframeCacheMap = new Map<string, HTMLIFrameElement>()
 const props = withDefaults(defineProps<{
   src: string
   inline?: boolean
+  onLoad?: (iframeEl: HTMLIFrameElement) => void
+  onClose?: (iframeEl: HTMLIFrameElement) => void
 }>(), {
   inline: false,
 })
@@ -27,20 +29,27 @@ onMounted(() => {
     iframeLoaded.value = true
   }
   else {
-    iframeEl.value = document.createElement('iframe')
-    iframeCacheMap.set(key.value, iframeEl.value)
-    iframeEl.value.src = props.src
+    const iframe = document.createElement('iframe')
+    iframeEl.value = iframe
+    iframeCacheMap.set(key.value, iframe)
+    iframe.addEventListener('load', () => {
+      props.onLoad?.(iframe)
+    })
+    iframe.addEventListener('close', () => {
+      props.onClose?.(iframe)
+    })
+    iframe.src = props.src
     // CORS
     try {
-      iframeEl.value.style.opacity = '0.01'
-      iframeEl.value.onload = () => {
+      iframe.style.opacity = '0.01'
+      iframe.onload = () => {
         syncColorMode()
-        iframeEl.value!.style.opacity = '1'
+        iframe!.style.opacity = '1'
         iframeLoaded.value = true
       }
     }
     catch (e) {
-      iframeEl.value.style.opacity = '1'
+      iframe.style.opacity = '1'
     }
 
     document.body.appendChild(iframeEl.value)

--- a/packages/client/src/components/common/IframeView.vue
+++ b/packages/client/src/components/common/IframeView.vue
@@ -8,11 +8,14 @@ const iframeCacheMap = new Map<string, HTMLIFrameElement>()
 const props = withDefaults(defineProps<{
   src: string
   inline?: boolean
-  onLoad?: (iframeEl: HTMLIFrameElement) => void
-  onClose?: (iframeEl: HTMLIFrameElement) => void
 }>(), {
   inline: false,
 })
+
+const emit = defineEmits<{
+  load: [iframeEl: HTMLIFrameElement]
+  close: [iframeEl: HTMLIFrameElement]
+}>()
 
 const { colorMode } = useDevToolsColorMode()
 const anchor = ref<HTMLDivElement>()
@@ -33,10 +36,10 @@ onMounted(() => {
     iframeEl.value = iframe
     iframeCacheMap.set(key.value, iframe)
     iframe.addEventListener('load', () => {
-      props.onLoad?.(iframe)
+      emit('load', iframe)
     })
     iframe.addEventListener('close', () => {
-      props.onClose?.(iframe)
+      emit('close', iframe)
     })
     iframe.src = props.src
     // CORS

--- a/packages/devtools-kit/src/types/tab.ts
+++ b/packages/devtools-kit/src/types/tab.ts
@@ -23,6 +23,20 @@ export interface ModuleIframeView {
    * @default true
    */
   persistent?: boolean
+
+  /**
+   * Triggered when the iframe is loaded
+   *
+   * @param iframe The iframe element
+   */
+  onLoad?: (iframe: HTMLIFrameElement) => void
+
+  /**
+   * Triggered when the iframe is closed if {@link persistent} is false
+   *
+   * @param iframe The iframe element
+   */
+  onClose?: (iframe: HTMLIFrameElement) => void
 }
 
 export interface ModuleVNodeView {

--- a/packages/vite/src/overlay.js
+++ b/packages/vite/src/overlay.js
@@ -30,6 +30,12 @@ addCustomTab({
   view: {
     type: 'iframe',
     src: normalizeUrl(`__inspect/`),
+    onLoad(iframe) {
+      console.log('iframe loaded', iframe)
+    },
+    onClose(iframe) {
+      console.log('iframe closed', iframe)
+    },
   },
   category: 'advanced',
 })


### PR DESCRIPTION
to allow custom integrations with iframes without compromising on a high level API yet:

```ts
  addCustomTab({
    name: 'pinia-colada',
    title: 'Pinia Colada',
    icon: 'https://pinia-colada.esm.dev/logo.svg',
    view: {
      type: 'iframe',
      src: '/__pinia-colada-devtools',
      persistent: false,
      onLoad(iframeEl: HTMLIFrameElement) {
        iframeEl.onclose

      },
      onClose(iframeEl: HTMLIFrameElement) {
      },
    },
    category: 'modules',
  })
```