### PR TITLE
fix(overlay): toggle component inspector

### DIFF
--- a/packages/overlay/src/App.vue
+++ b/packages/overlay/src/App.vue
@@ -84,7 +84,12 @@ const vueInspectorEnabled = computed(() => {
   return !!vueInspector.value
 })
 
-function enableVueInspector() {
+function toggleVueInspector() {
+  if(vueInspectorEnabled.value) {
+    vueInspector.value?.disable()
+    return
+  }
+
   vueInspector.value.enable()
 }
 
@@ -129,7 +134,7 @@ const { iframe, getIframe } = useIframe(clientUrl, async () => {
           class="vue-devtools__anchor-btn vue-devtools__panel-content vue-devtools__inspector-button"
           title="Toggle Component Inspector"
           :class="{ active: vueInspectorEnabled }"
-          @click="enableVueInspector"
+          @click="toggleVueInspector"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg" style="height: 1.1em; width: 1.1em; opacity:0.5;"


### PR DESCRIPTION
Toggling component inspector button does not toggle but only enable the inspector. I've tried to fixed that.