### PR TITLE
config: add allowImportingTsExtensions and noEmit to tsconfig

### DIFF
--- a/packages/ui/theme/index.ts
+++ b/packages/ui/theme/index.ts
@@ -1,2 +1,2 @@
-export * from './theme'
-export * from './uno.config'
+export * from './theme.ts'
+export * from './uno.config.ts'

--- a/packages/ui/theme/uno.config.ts
+++ b/packages/ui/theme/uno.config.ts
@@ -5,7 +5,7 @@ import {
   transformerDirectives,
   transformerVariantGroup,
 } from 'unocss'
-import { theme } from './theme'
+import { theme } from './theme.ts'
 
 export const unoConfig = {
   presets: [

--- a/packages/ui/uno.config.ts
+++ b/packages/ui/uno.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig } from 'unocss'
-import { unoConfig } from './theme'
+import { unoConfig } from './theme/index.ts'
 
 export default defineConfig(unoConfig)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,10 +19,12 @@
       "vite/client",
       "vitest/globals"
     ],
+    "allowImportingTsExtensions": true,
     "allowJs": true,
     "strict": true,
     "strictNullChecks": true,
     "noImplicitAny": false,
+    "noEmit": true,
     // We use tsup/vite instead of tsc to build the package, so we don't need to care about this option.
     // Add outDir option to avoid tsconfig error in monorepo.
     "outDir": "dist",

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'unocss'
 
-import config from './packages/client/uno.config'
+import config from './packages/client/uno.config.ts'
 
 export default defineConfig({
   ...config,


### PR DESCRIPTION
This pull request updates import paths across several files in the `packages/ui` directory to explicitly include `.ts` extensions. These changes ensure consistency and compatibility with TypeScript module resolution.

### Updates to import paths:

* [`packages/ui/theme/index.ts`](diffhunk://#diff-8c95d5109dce713c6defc436dc2ca2246b0016872833b8ee760e819abcc54cc6L1-R2): Changed export paths to include `.ts` extensions for `theme` and `uno.config`.
* [`packages/ui/theme/uno.config.ts`](diffhunk://#diff-40760a0c0f9c3d9c54c66d8658ae1eaf390a329cb138b587986214d7c80c5cc8L8-R8): Updated the import path for `theme` to explicitly include `.ts`.
* [`packages/ui/uno.config.ts`](diffhunk://#diff-111a862495ac1144601428643ca5de42c9ae2f1d3bc56f99d2a7b515a837ee50L2-R2): Modified the import path for `unoConfig` to include the `.ts` extension.
* [`uno.config.ts`](diffhunk://#diff-a1fce79a2a3c6ac87405bab70df3b135c47c2748e3a89b76e788cf03061ee370L3-R3): Updated the import path for `config` to include `.ts`.