### PR TITLE
fix: error fetching panel size during resize event

### DIFF
--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -145,7 +145,7 @@ watchEffect(() => {
       <SideNav v-if="!isUtilityView" of-x-hidden of-y-auto @toggle-devtools-client-visible="toggleDevToolsClientVisible" />
       <Splitpanes
         class="h-full of-hidden"
-        @resize="splitScreenSize = $event.map((v) => v.size)"
+        @resize="splitScreenSize = $event.panes.map((v) => v.size)"
       >
         <Pane h-full class="of-auto!" min-size="10" :size="splitScreenSize[0]">
           <RouterView />


### PR DESCRIPTION
the parameters of the `@resize` in `<Splitpanes>` have changed

<img width="600" alt="CleanShot 2025-07-25 at 15 16 22@2x" src="https://github.com/user-attachments/assets/c7872b09-6fbd-4dc6-af16-1807758dc236" />
