### PR TITLE
docs: fix the broken link of the playground

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -69,7 +69,7 @@ export default defineConfig({
       },
       {
         text: 'Playground',
-        link: 'https://stackblitz.com/github/vuejs/create-vue-templates/tree/main/devtools-router-pinia',
+        link: 'https://stackblitz.com/github/vuejs/create-vue-templates/tree/main/router-pinia',
       },
     ],
 


### PR DESCRIPTION
<img width="1512" height="818" alt="image" src="https://github.com/user-attachments/assets/05afad27-323f-4e1d-9c5b-2209870e9fea" />
<img width="1512" height="817" alt="image" src="https://github.com/user-attachments/assets/23082767-7ce4-495f-ac85-37a0116ee365" />

This [Playground Link](https://stackblitz.com/github/vuejs/create-vue-templates/tree/main/devtools-router-pinia) is broken, because this [create-vue-templates commit](https://github.com/vuejs/create-vue-templates/commit/ec95edd5ef951965e55fdd24499bdee63d5b5914).
We can use [router-pinia](https://stackblitz.com/github/vuejs/create-vue-templates/tree/main/router-pinia) instead.

<img width="1512" height="819" alt="image" src="https://github.com/user-attachments/assets/bcfbd6a7-11ff-4c34-a6da-210f59ab1b2b" />
