### PR TITLE
feat: enhance node import edge recognizability

### DIFF
--- a/packages/client/src/composables/graph.ts
+++ b/packages/client/src/composables/graph.ts
@@ -264,6 +264,11 @@ function getEdge(modId: string, dep: string) {
         enabled: true,
         scaleFactor: 0.8,
       },
+      from: {
+        enabled: true,
+        type: 'circle',
+        scaleFactor: 0.8,
+      },
     },
   }
 }


### PR DESCRIPTION
On complex nodes. It's difficult to find arrows pointing elsewhere. I’ve added markers at the tails of edges to improve readability.

| Before | After |
|--------|-------|
| <img height="300" alt="CleanShot 2025-11-05 at 12 54 36@2x" src="https://github.com/user-attachments/assets/b2bbcf0d-052b-4636-bd38-27df2dad016d" /> | <img height="300" alt="CleanShot 2025-11-05 at 12 53 06@2x" src="https://github.com/user-attachments/assets/198f02f2-cd61-4cf4-ae91-cfd7338d5320" /> |