### PR TITLE
FIX: Update css to prevent printing.

### DIFF
--- a/packages/overlay/src/App.vue
+++ b/packages/overlay/src/App.vue
@@ -307,7 +307,7 @@ const { iframe, getIframe } = useIframe(clientUrl, async () => {
 }
 
 @media print {
-  #vue-devtools-anchor {
+  .vue-devtools__anchor {
     display: none;
   }
 }


### PR DESCRIPTION
It took us quite a while to work out why we were getting a blank page at the end of our printout in only dev environments😅 

Seems like this was counted for at some point, but I'm guessing somebody changed the id of the anchor. This changes updates the old reference, using the class instead.