### PR TITLE
chore: update `ignoredBuiltDependencies` list

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,16 +119,6 @@
     "vitest": "^3.2.4",
     "vue": "^3.5.22"
   },
-  "pnpm": {
-    "ignoredBuiltDependencies": [
-      "core-js"
-    ],
-    "onlyBuiltDependencies": [
-      "electron",
-      "esbuild",
-      "vue-demi"
-    ]
-  },
   "simple-git-hooks": {
     "pre-commit": "pnpm lint-staged"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,3 +30,14 @@ catalog:
   vue: ^3.5.22
   vue-router: ^4.6.0
   vue-virtual-scroller: 2.0.0-beta.8
+
+ignoredBuiltDependencies:
+  - '@parcel/watcher'
+  - core-js
+  - simple-git-hooks
+  - yorkie
+
+onlyBuiltDependencies:
+  - electron
+  - esbuild
+  - vue-demi


### PR DESCRIPTION
Running `pnpm install` for this project will currently show a warning:

```
Ignored build scripts: @parcel/watcher, simple-git-hooks, yorkie.
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

This PR adds those 3 dependencies to `ignoredBuiltDependencies`, which suppresses that warning.

`simple-git-hooks` doesn't need to run because we also have `"prepare": "simple-git-hooks"` in `package.json`, which already runs during an install. Listing it in `onlyBuiltDependencies` would lead to it running twice, which is harmless but unnecessary.

As far as I'm aware, `yorkie` and `@parcel/watcher` are transient dependencies and we don't need them to run during an install.

I've also moved both `onlyBuiltDependencies` and `ignoredBuiltDependencies` to `pnpm-workspace.yaml`, rather than having them in `package.json`. When pnpm 10.0.0 was first released, the [release notes](https://github.com/pnpm/pnpm/releases/tag/v10.0.0) recommended adding `onlyBuiltDependencies` to `package.json`, which is what #810 did. But there were various changes and additions to the feature in later v10 releases. I think `pnpm-workspace.yaml` is the more natural home for pnpm-specific configuration and is where `pnpm` saves them by default when running `pnpm approve-builds` ([docs](https://pnpm.io/cli/approve-builds)).