### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,6 @@
   ],
   "ignoreDeps": [
     "node",
-    "nanoid",
     "vite-plugin-inspect"
   ],
   "labels": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,11 +31,7 @@
   },
   "dependencies": {
     "@vue/devtools-kit": "workspace:^",
-    "@vue/devtools-shared": "workspace:^",
-    "mitt": "catalog:",
-    "nanoid": "^5.1.5",
-    "pathe": "catalog:",
-    "vite-hot-client": "catalog:"
+    "@vue/devtools-shared": "workspace:^"
   },
   "devDependencies": {
     "vue": "catalog:"

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -7,9 +7,6 @@ export default defineConfig({
   external: [
     'vue',
   ],
-  noExternal: [
-    'vite-hot-client',
-  ],
   // clean: true,
   format: ['esm', 'cjs'],
   dts: true,

--- a/packages/devtools-kit/package.json
+++ b/packages/devtools-kit/package.json
@@ -31,7 +31,6 @@
     "@vue/devtools-shared": "workspace:^",
     "birpc": "^2.6.1",
     "hookable": "^5.5.3",
-    "mitt": "catalog:",
     "perfect-debounce": "catalog:",
     "speakingurl": "^14.0.1",
     "superjson": "^2.2.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,84 +6,9 @@ settings:
 
 catalogs:
   default:
-    '@iconify/json':
-      specifier: ^2.2.395
-      version: 2.2.395
-    '@types/node':
-      specifier: ^24.7.2
-      version: 24.7.2
-    '@unocss/reset':
-      specifier: ^66.5.4
-      version: 66.5.4
-    '@vitejs/plugin-vue':
-      specifier: ^6.0.1
-      version: 6.0.1
-    '@vueuse/core':
-      specifier: ^13.9.0
-      version: 13.9.0
-    '@vueuse/integrations':
-      specifier: ^13.9.0
-      version: 13.9.0
-    colord:
-      specifier: ^2.9.3
-      version: 2.9.3
-    floating-vue:
-      specifier: 5.2.2
-      version: 5.2.2
-    mitt:
-      specifier: ^3.0.1
-      version: 3.0.1
-    pathe:
-      specifier: ^2.0.3
-      version: 2.0.3
-    perfect-debounce:
-      specifier: ^2.0.0
-      version: 2.0.0
-    pinia:
-      specifier: ^3.0.3
-      version: 3.0.3
-    sass-embedded:
-      specifier: ^1.93.2
-      version: 1.93.2
-    serve:
-      specifier: ^14.2.5
-      version: 14.2.5
-    shiki:
-      specifier: ^3.13.0
-      version: 3.13.0
-    splitpanes:
-      specifier: ^4.0.4
-      version: 4.0.4
-    typescript:
-      specifier: ^5.9.3
-      version: 5.9.3
-    unocss:
-      specifier: ^66.5.4
-      version: 66.5.4
-    unplugin-auto-import:
-      specifier: ^20.2.0
-      version: 20.2.0
-    vite:
-      specifier: ^7.1.10
-      version: 7.1.10
-    vite-hot-client:
-      specifier: ^2.1.0
-      version: 2.1.0
-    vite-plugin-dts:
-      specifier: ^4.5.4
-      version: 4.5.4
-    vite-plugin-inspect:
-      specifier: ^11.3.3
-      version: 11.3.3
     vue:
       specifier: ^3.5.22
       version: 3.5.22
-    vue-router:
-      specifier: ^4.6.0
-      version: 4.6.0
-    vue-virtual-scroller:
-      specifier: 2.0.0-beta.8
-      version: 2.0.0-beta.8
 
 importers:
 
@@ -434,18 +359,6 @@ importers:
       '@vue/devtools-shared':
         specifier: workspace:^
         version: link:../shared
-      mitt:
-        specifier: 'catalog:'
-        version: 3.0.1
-      nanoid:
-        specifier: ^5.1.5
-        version: 5.1.5
-      pathe:
-        specifier: 'catalog:'
-        version: 2.0.3
-      vite-hot-client:
-        specifier: 'catalog:'
-        version: 2.1.0(vite@7.1.10(@types/node@24.7.2)(jiti@2.5.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
     devDependencies:
       vue:
         specifier: 'catalog:'
@@ -477,9 +390,6 @@ importers:
       hookable:
         specifier: ^5.5.3
         version: 5.5.3
-      mitt:
-        specifier: 'catalog:'
-        version: 3.0.1
       perfect-debounce:
         specifier: 'catalog:'
         version: 2.0.0
@@ -6825,11 +6735,6 @@ packages:
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@5.1.5:
-    resolution: {integrity: sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==}
-    engines: {node: ^18 || >=20}
     hasBin: true
 
   natural-compare@1.4.0:
@@ -16313,8 +16218,6 @@ snapshots:
   nano-spawn@2.0.0: {}
 
   nanoid@3.3.11: {}
-
-  nanoid@5.1.5: {}
 
   natural-compare@1.4.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,6 @@ catalog:
   '@vueuse/integrations': ^13.9.0
   colord: ^2.9.3
   floating-vue: 5.2.2
-  mitt: ^3.0.1
   pathe: ^2.0.3
   perfect-debounce: ^2.0.0
   pinia: ^3.0.3


### PR DESCRIPTION
There are some dependencies that seem unused now.

I used `pnpm remove` to remove them so pnpm updates the lockfile instead of rebuilding and upgrading unrelated dependencies. For some reason `pnpm remove` edited the lockfile catalogs field but it doesn't seem to affect anything.