### PR TITLE
feat: show VNode lifecycle events as 'built-in'

### DIFF
--- a/packages/devtools-kit/src/core/component/state/process.ts
+++ b/packages/devtools-kit/src/core/component/state/process.ts
@@ -3,7 +3,7 @@ import type { InspectorState } from '../types'
 import { camelize } from '@vue/devtools-shared'
 import { ensurePropertyExists, returnError } from '../utils'
 import { vueBuiltins } from './constants'
-import { getPropType, getSetupStateType, toRaw } from './util'
+import { escape, getPropType, getSetupStateType, toRaw } from './util'
 
 function mergeOptions(
   to: any,
@@ -279,6 +279,15 @@ function processRefs(instance: VueAppInstance) {
     }))
 }
 
+const vnodeEvents = new Set([
+  'vnode-before-mount',
+  'vnode-mounted',
+  'vnode-before-update',
+  'vnode-updated',
+  'vnode-before-unmount',
+  'vnode-unmounted',
+])
+
 function processEventListeners(instance: VueAppInstance) {
   const emitsDefinition = instance.type.emits
   const declaredEmits = Array.isArray(emitsDefinition) ? emitsDefinition : Object.keys(emitsDefinition ?? {})
@@ -288,16 +297,18 @@ function processEventListeners(instance: VueAppInstance) {
     const [prefix, ...eventNameParts] = key.split(/(?=[A-Z])/)
     if (prefix === 'on') {
       const eventName = eventNameParts.join('-').toLowerCase()
+      const isBuiltIn = vnodeEvents.has(eventName)
       const isDeclared = declaredEmits.includes(eventName)
+      const text = isBuiltIn ? '✅ Built-in' : isDeclared ? '✅ Declared' : '⚠️ Not declared'
       result.push({
         type: 'event listeners',
         key: eventName,
         value: {
           _custom: {
-            displayText: isDeclared ? '✅ Declared' : '⚠️ Not declared',
-            key: isDeclared ? '✅ Declared' : '⚠️ Not declared',
-            value: isDeclared ? '✅ Declared' : '⚠️ Not declared',
-            tooltipText: !isDeclared ? `The event <code>${eventName}</code> is not declared in the <code>emits</code> option. It will leak into the component's attributes (<code>$attrs</code>).` : null,
+            displayText: text,
+            key: text,
+            value: text,
+            tooltipText: isBuiltIn ? `The event <code>${escape(eventName)}</code> is part of Vue and doesn't need to be declared by the component` : !isDeclared ? `The event <code>${escape(eventName)}</code> is not declared in the <code>emits</code> option. It will leak into the component's attributes (<code>$attrs</code>).` : null,
           },
         },
       })


### PR DESCRIPTION
Fixes #878 .

Vue includes some built-in lifecycle events for VNodes. See:

- https://github.com/vuejs/core/blob/0b30b7d3be5185041b790286da8402dd10503dbb/packages/shared/src/general.ts#L86

These don't need to be declared by components, as they're implemented by Vue itself and aren't emitted manually.

Rather than rendering them as `Undeclared`, I've added a third state, `Built-in`:

<img width="282" height="90" alt="image" src="https://github.com/user-attachments/assets/dd48468e-c34b-4960-997e-ef4487b4db83" />

While these lifecycle events are rarely used directly, Vue Router adds a `vnode-unmounted` listener to route components. Showing that listener as `Undeclared` is misleading, implying user error.

I've included a tooltip for the new state. I don't think there's currently any way to see that tooltip, as they aren't implemented in the UI, but I'll attempt a fix for that in a separate PR.

---

Side note: I tested this using the Vite plugin. I kept running into problems and eventually realised these were being caused by the `Vue.js devtools` Chrome extension. I wasn't intentionally using the Chrome extension, it just happened to be installed. My code was setting the values to `Built-in` and the extension was overwriting that with `Undeclared`. Once I realised I just disabled the extension, but the thought occurs that this sharing of data is likely to lead to compatibility problems more generally. I couldn't find this documented anywhere and it seems kinda scary that the extension can interfere like that.