### PR TITLE
chore: add `.turbo` to `ignoreWatch`

### DIFF
--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -12,4 +12,5 @@ export default defineConfig({
   dts: true,
   shims: true,
   hash: false,
+  ignoreWatch: ['.turbo'],
 })

--- a/packages/devtools-api/tsdown.config.ts
+++ b/packages/devtools-api/tsdown.config.ts
@@ -7,6 +7,7 @@ const baseConfig = defineConfig({
   ],
   shims: true,
   hash: false,
+  ignoreWatch: ['.turbo'],
 })
 
 const esmBundlerConfig = defineConfig({

--- a/packages/devtools-kit/tsdown.config.ts
+++ b/packages/devtools-kit/tsdown.config.ts
@@ -9,4 +9,5 @@ export default defineConfig({
   dts: true,
   shims: true,
   hash: false,
+  ignoreWatch: ['.turbo'],
 })

--- a/packages/devtools/tsdown.config.ts
+++ b/packages/devtools/tsdown.config.ts
@@ -13,4 +13,5 @@ export default defineConfig({
   dts: true,
   shims: true,
   hash: false,
+  ignoreWatch: ['.turbo'],
 })

--- a/packages/shared/tsdown.config.ts
+++ b/packages/shared/tsdown.config.ts
@@ -9,4 +9,5 @@ export default defineConfig({
   dts: true,
   shims: true,
   hash: false,
+  ignoreWatch: ['.turbo'],
 })

--- a/packages/vite/tsdown.config.ts
+++ b/packages/vite/tsdown.config.ts
@@ -8,4 +8,5 @@ export default defineConfig({
   format: ['esm', 'cjs'],
   hash: false,
   dts: true,
+  ignoreWatch: ['.turbo'],
 })


### PR DESCRIPTION
While trying to build the project in watch mode (`pnpm dev`), I found it got into an infinite build loop.

`pnpm dev` is using `turbo` to run the builds. The `tsdown` builds succeed, but this updates the log files in the `.turbo` directories, triggering the watcher to re-run the builds. This updates the logs again and the whole process keeps repeating over and over.

I've added `ignoreWatch: ['.turbo']` to the `tsdown.config.ts` files, so the watcher won't watch those logs.

It isn't clear to me whether this a new problem or something that's not worked for a while. I believe `tsup` works the same way as `tsdown`, <https://tsup.egoist.dev/#watch-mode>. Perhaps there's some platform-specific reason why I'm getting this infinite loop, or maybe `pnpm dev` isn't commonly used?