### PR TITLE
build: rename `entryPoints` to `entry`

### DIFF
--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -1,9 +1,7 @@
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  entryPoints: [
-    'src/index.ts',
-  ],
+  entry: 'src/index.ts',
   external: [
     'vue',
   ],

--- a/packages/devtools-kit/tsdown.config.ts
+++ b/packages/devtools-kit/tsdown.config.ts
@@ -1,9 +1,7 @@
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  entryPoints: [
-    'src/index.ts',
-  ],
+  entry: 'src/index.ts',
   clean: true,
   format: ['esm', 'cjs'],
   dts: true,

--- a/packages/devtools/tsdown.config.ts
+++ b/packages/devtools/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  entryPoints: [
+  entry: [
     'src/index.ts',
     'src/hook.ts',
   ],

--- a/packages/shared/tsdown.config.ts
+++ b/packages/shared/tsdown.config.ts
@@ -1,9 +1,7 @@
 import { defineConfig } from 'tsdown'
 
 export default defineConfig({
-  entryPoints: [
-    'src/index.ts',
-  ],
+  entry: 'src/index.ts',
   clean: true,
   format: ['esm', 'cjs'],
   dts: true,


### PR DESCRIPTION
Type checking is currently failing for some of the `tsdown` configs because they use `entryPoints` rather than `entry`.

Both settings do work, but `entryPoints` is the old `tsup` name and isn't included in the types.

References:
- <https://tsdown.dev/options/entry>
- <https://github.com/rolldown/tsdown/blob/e4230d1f25ab59a57db0f27deb46480d546e7d59/packages/migrate/src/helpers/tsup-config.ts#L33>