### PR TITLE
fix: use `displayName` for functional components

### DIFF
--- a/packages/devtools-kit/src/core/component/utils/index.ts
+++ b/packages/devtools-kit/src/core/component/utils/index.ts
@@ -2,6 +2,9 @@ import type { AppRecord, VueAppInstance } from '../../../types'
 import { basename, classify } from '@vue/devtools-shared'
 
 function getComponentTypeName(options: VueAppInstance['type']) {
+  if (typeof options === 'function') {
+    return options.displayName || options.name || options.__VUE_DEVTOOLS_COMPONENT_GUSSED_NAME__ || ''
+  }
   const name = options.name || options._componentTag || options.__VUE_DEVTOOLS_COMPONENT_GUSSED_NAME__ || options.__name
   if (name === 'index' && options.__file?.endsWith('index.vue')) {
     return ''


### PR DESCRIPTION
Closes #690.

---

The `Transition` component is shown as `Anonymous Component` in various places, e.g. in the component inspection tree:

<img width="256" height="39" alt="image" src="https://github.com/user-attachments/assets/3c7bb640-2f38-412e-9b74-307a3c389594" />

This will now be shown as `Transition` instead:

<img width="186" height="39" alt="image" src="https://github.com/user-attachments/assets/d8dcd732-b8a8-4204-bd23-2376009a461e" />

---

This fix also applies to other functional components with a `displayName` property.

Using the `displayName` in this way is consistent with how Vue core uses it:

- <https://github.com/vuejs/core/blob/09dec962ae9c2e2ad49e584cef5f416a0d4558ff/packages/runtime-core/src/component.ts#L1215>