### PR TITLE
fix: match camelCase event declarations

### DIFF
--- a/packages/devtools-kit/src/core/component/state/process.ts
+++ b/packages/devtools-kit/src/core/component/state/process.ts
@@ -298,7 +298,7 @@ function processEventListeners(instance: VueAppInstance) {
     if (prefix === 'on') {
       const eventName = eventNameParts.join('-').toLowerCase()
       const isBuiltIn = vnodeEvents.has(eventName)
-      const isDeclared = declaredEmits.includes(eventName)
+      const isDeclared = declaredEmits.includes(eventName) || declaredEmits.includes(camelize(eventName))
       const text = isBuiltIn ? '✅ Built-in' : isDeclared ? '✅ Declared' : '⚠️ Not declared'
       result.push({
         type: 'event listeners',


### PR DESCRIPTION
Fixes #651.

`defineModel()` declares an event using `emits: ['update:modelValue']`. The DevTools only consider kebab-case when checking whether an event is declared, leading to a warning when using `v-model`:

<img width="333" height="51" alt="image" src="https://github.com/user-attachments/assets/8ea32005-9eca-4a33-afe2-88b0ad095e4b" />

The problem is not limited to `defineModel`/`v-model`, it applies to all events in `emits` that use camelCase.

This PR adds a check for those event names:

<img width="323" height="48" alt="image" src="https://github.com/user-attachments/assets/3c86bed4-bf97-4825-a26a-b815ab12c1bc" />