### PR TITLE
fix: `computed` and `inject` leak via mixins

### DIFF
--- a/packages/devtools-kit/src/core/component/state/process.ts
+++ b/packages/devtools-kit/src/core/component/state/process.ts
@@ -26,11 +26,8 @@ function mergeOptions(
 
   for (const key of ['computed', 'inject']) {
     if (Object.prototype.hasOwnProperty.call(from, key)) {
-      if (!to[key])
-        to[key] = from[key]
-
-      else
-        Object.assign(to[key], from[key])
+      to[key] ??= {}
+      Object.assign(to[key], from[key])
     }
   }
   return to


### PR DESCRIPTION
Fixes #1049.

An example to reproduce the problem:

```html
<script setup>
import { h } from 'vue'

const Mixin = {
  computed: {
    a() {
      return 1
    },
  },
}

const Comp1 = {
  mixins: [Mixin],
  computed: {
    b() {
      return 2
    },
  },
  render() {
    return h('div', 'comp 1')
  },
}

const Comp2 = {
  mixins: [Mixin],
  render() {
    return h('div', 'comp 2')
  },
}
</script>

<template>
  <div>
    <Comp1 />
    <hr>
    <Comp2 />
  </div>
</template>
```

In this example, inspecting `Comp2` shows a `computed` property called `b`, even though `Comp2` doesn't have a property called `b`. That property has leaked from `Comp1`, via the mixin.

In `mergeOptions`, we currently have this line:

```ts
to[key] = from[key]
```

That's using the original object from the mixin, not a copy. This is the underlying problem. Later we hit this line:

```ts
Object.assign(to[key], from[key])
```

That modifies `to[key]`, adding properties from `from[key]`. In my earlier example, `to[key]` is the `computed` object from the mixin, and this copies in the property `b` from `Comp2`.

The same problem applies to `inject`.