### PR TITLE
refactor: remove unused variables

### DIFF
--- a/docs/.vitepress/components/UseModeList.vue
+++ b/docs/.vitepress/components/UseModeList.vue
@@ -1,7 +1,4 @@
 <script setup lang="ts">
-import { useRouter } from 'vitepress'
-
-const router = useRouter()
 const list = [
   {
     name: 'Vite Plugin',

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -19,7 +19,11 @@ export default antfu({
 
     'no-console': 'off',
     'antfu/top-level-function': 'off',
-    'unused-imports/no-unused-vars': 'off',
+    'unused-imports/no-unused-vars': ['error', {
+      args: 'none',
+      caughtErrors: 'none',
+      ignoreRestSiblings: true,
+    }],
 
     'node/prefer-global/process': 'off',
 
@@ -36,6 +40,11 @@ export default antfu({
   plugins: { devtools },
   rules: {
     'devtools/no-vue-runtime-import': ['error', { prefer: 'shared/stub-vue' }],
+  },
+}, {
+  files: ['packages/playground/**/*.vue', '**/*.md/*'],
+  rules: {
+    'unused-imports/no-unused-vars': 'off',
   },
 }, {
   ignores: [

--- a/packages/applet/src/components/tree/TreeViewer.vue
+++ b/packages/applet/src/components/tree/TreeViewer.vue
@@ -5,10 +5,9 @@ import { vTooltip } from '@vue/devtools-ui'
 import NodeTag from '~/components/basic/NodeTag.vue'
 import ToggleExpanded from '~/components/basic/ToggleExpanded.vue'
 import ComponentTreeViewer from '~/components/tree/TreeViewer.vue'
-import { useSelect } from '~/composables/select'
 import { useToggleExpanded } from '~/composables/toggle-expanded'
 
-const props = withDefaults(defineProps<{
+withDefaults(defineProps<{
   data: ComponentTreeNode[] | InspectorTree[]
   depth: number
   withTag: boolean
@@ -19,7 +18,6 @@ const props = withDefaults(defineProps<{
 const emit = defineEmits(['hover', 'leave'])
 const selectedNodeId = defineModel()
 const { expanded, toggleExpanded } = useToggleExpanded()
-const { select: _select } = useSelect()
 
 function normalizeLabel(item: ComponentTreeNode | InspectorTree) {
   return ('name' in item && item?.name) || ('label' in item && item.label)

--- a/packages/applet/src/modules/pinia/components/Settings.vue
+++ b/packages/applet/src/modules/pinia/components/Settings.vue
@@ -11,7 +11,6 @@ const settings = inject<Ref<{
 }>>('pluginSettings')!
 const options = computed(() => settings.value.options)
 const values = computed(() => settings.value.values)
-const inspectorId = 'pinia'
 
 function update(_settings) {
   settings.value = _settings

--- a/packages/applet/src/modules/pinia/index.vue
+++ b/packages/applet/src/modules/pinia/index.vue
@@ -41,7 +41,7 @@ const routes = computed(() => {
   ].filter(Boolean) as VirtualRoute[]
 })
 
-const { VirtualRouterView, restoreRouter } = registerVirtualRouter(routes, {
+const { VirtualRouterView } = registerVirtualRouter(routes, {
   defaultRoutePath: '/store',
 })
 

--- a/packages/chrome-extension/src/devtools-overlay.ts
+++ b/packages/chrome-extension/src/devtools-overlay.ts
@@ -1,6 +1,4 @@
 if (document instanceof HTMLDocument) {
-  const body = document.getElementsByTagName('body')[0]
-
   // create detector script
   const detector = document.createElement('script')
   detector.src = chrome.runtime.getURL('dist/detector.js')

--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -6,7 +6,6 @@ import { Pane, Splitpanes } from 'splitpanes'
 useDevToolsColorMode()
 const router = useRouter()
 const route = useRoute()
-const hostEnv = useHostEnv()
 const { connected, clientConnected, activeAppRecordId: _activeAppRecordId, appRecords: _appRecords } = useDevToolsState()
 const clientState = devtoolsClientState
 

--- a/packages/client/src/components/timeline/TimelineLayers.vue
+++ b/packages/client/src/components/timeline/TimelineLayers.vue
@@ -13,8 +13,7 @@ const devtoolsState = useDevToolsState()
 const recordingState = computed(() => devtoolsState.timelineLayersState.value.recordingState)
 const timelineLayersState = computed(() => devtoolsState.timelineLayersState.value)
 const recordingTooltip = computed(() => recordingState.value ? 'Stop recording' : 'Start recording')
-const { colorMode } = useDevToolsColorMode()
-const isDark = computed(() => colorMode.value === 'dark')
+useDevToolsColorMode()
 const selected = defineModel()
 function select(id: string) {
   selected.value = id

--- a/packages/client/src/composables/editor.ts
+++ b/packages/client/src/composables/editor.ts
@@ -9,10 +9,7 @@ export function useCopy() {
   const { copy: _copy, copied } = useClipboard()
 
   const copy = (text: string, options: CopyOptions = {}) => {
-    const {
-      silent = false,
-      type = '',
-    } = options
+    const { silent = false } = options
     _copy(text).then(() => {
       if (!silent) {
         showVueNotification({

--- a/packages/devtools-kit/src/core/plugin/components.ts
+++ b/packages/devtools-kit/src/core/plugin/components.ts
@@ -86,7 +86,7 @@ export function createComponentsDevToolsPlugin(app: App): [PluginDescriptor, Plu
       api.sendInspectorState(INSPECTOR_ID)
     }, 120)
 
-    const componentAddedCleanup = hook.on.componentAdded(async (app, uid, parentUid, component) => {
+    hook.on.componentAdded(async (app, uid, parentUid, component) => {
       if (devtoolsState.highPerfModeEnabled)
         return
 
@@ -121,7 +121,7 @@ export function createComponentsDevToolsPlugin(app: App): [PluginDescriptor, Plu
       debounceSendInspectorTree()
     })
 
-    const componentUpdatedCleanup = hook.on.componentUpdated(async (app, uid, parentUid, component) => {
+    hook.on.componentUpdated(async (app, uid, parentUid, component) => {
       if (devtoolsState.highPerfModeEnabled)
         return
 
@@ -156,7 +156,7 @@ export function createComponentsDevToolsPlugin(app: App): [PluginDescriptor, Plu
       debounceSendInspectorTree()
       debounceSendInspectorState()
     })
-    const componentRemovedCleanup = hook.on.componentRemoved(async (app, uid, parentUid, component) => {
+    hook.on.componentRemoved(async (app, uid, parentUid, component) => {
       if (devtoolsState.highPerfModeEnabled)
         return
 

--- a/packages/devtools-kit/src/ctx/state.ts
+++ b/packages/devtools-kit/src/ctx/state.ts
@@ -129,8 +129,6 @@ export const devtoolsState: DevToolsState = new Proxy(global[STATE_KEY], {
     return true
   },
   set(target, property, value) {
-    const oldState = { ...global[STATE_KEY] }
-
     target[property] = value
     global[STATE_KEY][property] = value
 

--- a/packages/electron/src/devtools.ts
+++ b/packages/electron/src/devtools.ts
@@ -17,7 +17,6 @@ function address() {
 function init() {
   const localhost = `http://localhost:${port}`
   const socket = io(localhost)
-  let reload: Function | null = null
 
   const app = createConnectionApp('#app', {
     local: localhost,
@@ -35,7 +34,6 @@ function init() {
 
   function shutdown() {
     app.unmount()
-    reload = null
     socket.close()
     init()
   }

--- a/packages/firefox-extension/src/devtools-overlay.ts
+++ b/packages/firefox-extension/src/devtools-overlay.ts
@@ -1,6 +1,4 @@
 if (document instanceof HTMLDocument) {
-  const body = document.getElementsByTagName('body')[0]
-
   // create detector script
   const detector = document.createElement('script')
   detector.src = chrome.runtime.getURL('dist/detector.js')

--- a/packages/firefox-extension/src/devtools-panel.ts
+++ b/packages/firefox-extension/src/devtools-panel.ts
@@ -2,20 +2,6 @@ import { functions, onRpcConnected } from '@vue/devtools-core'
 import { createRpcClient } from '@vue/devtools-kit'
 import { disconnectDevToolsClient, initDevTools, reloadDevToolsClient } from '../client/devtools-panel'
 
-const connectionInfo: {
-  retryTimer: NodeJS.Timeout | null
-  count: number
-  disconnected: boolean
-  port: chrome.runtime.Port
-  listeners: Array<() => void>
-} = {
-  retryTimer: null,
-  count: 0,
-  disconnected: false,
-  port: null!,
-  listeners: [],
-}
-
 function init() {
   injectScript(chrome.runtime.getURL('dist/user-app.js'), () => {
     initDevTools()

--- a/packages/overlay/src/App.vue
+++ b/packages/overlay/src/App.vue
@@ -39,7 +39,7 @@ target.__VUE_DEVTOOLS_TOGGLE_OVERLAY__ = (visible: boolean) => {
   overlayVisible.value = visible
 }
 
-const { updateState, state } = useFrameState()
+const { state } = useFrameState()
 function waitForClientInjection(iframe: HTMLIFrameElement, retry = 50, timeout = 200): Promise<void> | void {
   return new Promise((resolve) => {
     iframe?.contentWindow?.postMessage('__VUE_DEVTOOLS_CREATE_CLIENT__', '*')
@@ -88,7 +88,7 @@ function enableVueInspector() {
   vueInspector.value.enable()
 }
 
-const { iframe, getIframe } = useIframe(clientUrl, async () => {
+const { getIframe } = useIframe(clientUrl, async () => {
   const iframe = getIframe()
   setIframeServerContext(iframe)
   await waitForClientInjection(iframe)

--- a/packages/vite/src/rpc/assets.ts
+++ b/packages/vite/src/rpc/assets.ts
@@ -7,37 +7,6 @@ import { join, relative, resolve } from 'pathe'
 import { debounce } from 'perfect-debounce'
 import { RpcFunctionCtx } from './types'
 
-const defaultAllowedExtensions = [
-  'png',
-  'jpg',
-  'jpeg',
-  'gif',
-  'svg',
-  'webp',
-  'ico',
-  'mp4',
-  'ogg',
-  'mp3',
-  'wav',
-  'mov',
-  'mkv',
-  'mpg',
-  'txt',
-  'ttf',
-  'woff',
-  'woff2',
-  'eot',
-  'json',
-  'js',
-  'jsx',
-  'ts',
-  'tsx',
-  'md',
-  'mdx',
-  'vue',
-  'webm',
-]
-
 function guessType(path: string): AssetType {
   if (/\.(?:png|jpe?g|jxl|gif|svg|webp|avif|ico|bmp|tiff?)$/i.test(path))
     return 'image'


### PR DESCRIPTION
I've enabled `unused-imports/no-unused-vars` in the ESLint config and removed the unused variables it found.

I only wanted to enable minimal checks, so I've set `args: 'none'`, `caughtErrors: 'none'` and `ignoreRestSiblings: true`, which disable the checks in various other cases.

I also disabled the checks for `packages/playground/**/*.vue` and `**/*.md/*`. The former allows the `<script setup>` components in the playgrounds to have 'unused' variables for testing the devtools. The latter refers to code examples in `.md` files, which are often incomplete code fragments.

When removing the variable, I often had to make a decision about whether to also remove the expression on the right-hand side of the assignment. In most cases this seemed obvious, but the call to `useDevToolsColorMode()` in `TimelineLayers.vue` was unclear to me, so I left it in.

In most cases the unused variable was used in an earlier version of the code, and only became unused due to other changes. But in some cases the variable has never been used, which might be indicative of unfinished code. Perhaps the variable *should* be used. I wasn't really able to assess that properly, I could only check whether it's used now.