### PR TITLE
ci: add type checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,5 +37,8 @@ jobs:
       - name: Lint
         run: nr lint
 
+      - name: Type check
+        run: nr type-check
+
       - name: Test
         run: nr test

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "lint": "NODE_OPTIONS=--import=tsx eslint --config=eslint.config.ts .",
     "lint:fix": "pnpm lint --fix",
     "lint:packages": "pnpm -r --filter='./packages/{core,devtools,devtools-api,devtools-kit,electron,shared,applet}' exec publint && pnpm -r --filter='./packages/{core,devtools,devtools-api,devtools-kit,electron,shared,applet}' exec attw --pack",
+    "type-check": "tsc --project ./tsconfig.ci.json",
     "prepublishOnly": "npm run build",
     "release": "bumpp -r",
     "dep:up": "taze -I major -r",

--- a/tsconfig.ci.json
+++ b/tsconfig.ci.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "packages/shared",
+    "packages/devtools-kit",
+    "packages/devtools-api",
+    "packages/core"
+  ],
+  "exclude": [
+    "packages/devtools-kit/__tests__",
+    "**/vite/src/overlay/**",
+    "**/dist/**",
+    "**/node_modules/**",
+    "**/**/*.js"
+  ]
+}


### PR DESCRIPTION
This PR adds type checking to the GitHub CI workflow.

I've limited the type checking to specific packages: `shared`, `devtools-kit`, `devtools-api` and `core`. Ideally we'd check everything, but that'll need some more work and I think it's worth taking this small step first and then gradually adding the rest later.

The main `tsconfig.json` used by the IDE is unchanged. I've added `tsconfig.ci.json` to limit the scope of the checks in the CI. That config inherits most of its settings from the main `tsconfig.json`. Longer term I hope we'll be able to remove `tsconfig.ci.json` and just use `tsconfig.json` directly.

The checks can also be run locally using `pnpm run type-check`. I'm also hoping to add a pre-commit hook with `simple-git-hooks`, but in the interests of keeping this PR simple I haven't added that yet.