### PR TITLE
ci: run CI for all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - '**'
 
   pull_request:
     branches:


### PR DESCRIPTION
This configuration change runs the CI workflow on pushes to all branches, not just `main`.

With the current workflow the CI job typically only runs once a PR is opened. With this change it'll run as soon as a change is pushed to a branch on a fork, so we get the CI check before opening a PR. Personally I would find this useful, to help ensure I don't open PRs that fail CI.