### PR TITLE
build: remove `api: 'modern-compiler'`

### DIFF
--- a/packages/client/vite.base.config.ts
+++ b/packages/client/vite.base.config.ts
@@ -11,13 +11,6 @@ export default {
       '~/': `${resolve(__dirname)}/src/`,
     },
   },
-  css: {
-    preprocessorOptions: {
-      scss: {
-        api: 'modern-compiler',
-      },
-    },
-  },
   build: {
     chunkSizeWarningLimit: 5000,
   },

--- a/packages/overlay/vite.config.ts
+++ b/packages/overlay/vite.config.ts
@@ -9,13 +9,6 @@ export default defineConfig({
       '~/': `${resolve(__dirname)}/src/`,
     },
   },
-  css: {
-    preprocessorOptions: {
-      scss: {
-        api: 'modern-compiler',
-      },
-    },
-  },
   define: {
     'process.env': process.env,
   },

--- a/packages/playground/applet/vite.config.ts
+++ b/packages/playground/applet/vite.config.ts
@@ -20,13 +20,6 @@ export default defineConfig({
       ignore: ['h'],
     }),
   ],
-  css: {
-    preprocessorOptions: {
-      scss: {
-        api: 'modern-compiler',
-      },
-    },
-  },
   server: {
     port: 3000,
   },

--- a/packages/playground/basic/vite.config.ts
+++ b/packages/playground/basic/vite.config.ts
@@ -9,13 +9,6 @@ import VueDevTools from 'vite-plugin-vue-devtools'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  css: {
-    preprocessorOptions: {
-      scss: {
-        api: 'modern-compiler',
-      },
-    },
-  },
   plugins: [
     vue(),
     commonjs(),

--- a/packages/playground/multi-app/vite.config.ts
+++ b/packages/playground/multi-app/vite.config.ts
@@ -7,13 +7,6 @@ import VueDevtools from 'vite-plugin-vue-devtools'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  css: {
-    preprocessorOptions: {
-      scss: {
-        api: 'modern-compiler',
-      },
-    },
-  },
   plugins: [
     vue(),
     VueDevtools(),


### PR DESCRIPTION
The Vite setting `css.preprocessorOptions.scss.api: 'modern-compiler'` was added in #665, which was needed with Vite 5.

- In Vite 6, the default value of this setting was changed to `'modern-compiler'`. [Details](https://v6.vite.dev/guide/migration.html#sass-now-uses-modern-api-by-default)
- In Vite 7, this setting was removed. [Details](https://v7.vite.dev/guide/migration#removed-sass-legacy-api-support)

We're now using Vite 7, so it should be removed. Currently it causes a TS error when type checking the Vite config files.