### PR TITLE
refactor(ui): fix type errors

### DIFF
--- a/packages/ui/src/components/DropdownButton.vue
+++ b/packages/ui/src/components/DropdownButton.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ComputedGetter } from 'vue'
+import type { ComputedRef } from 'vue'
 import type { ButtonProps } from './Button.vue'
 import { vClosePopper } from 'floating-vue'
 import { inject } from 'vue'
@@ -11,7 +11,7 @@ const props = withDefaults(defineProps<ButtonProps & {
   keepOpen: false,
 })
 
-const disabled = inject<ComputedGetter<boolean> | undefined>('$ui-dropdown-disabled', undefined)!
+const disabled = inject<ComputedRef<boolean> | undefined>('$ui-dropdown-disabled', undefined)!
 </script>
 
 <template>

--- a/packages/ui/storybook/Dropdown.story.vue
+++ b/packages/ui/storybook/Dropdown.story.vue
@@ -18,10 +18,9 @@ const disabled = ref(false)
         v-model="placement"
         title="Placement"
         :options="placements.reduce((acc, placement) => {
-          // @ts-expect-error
           acc[placement] = placement
           return acc
-        }, {})"
+        }, {} as Record<Placement, Placement>)"
       />
       <HstCheckbox v-model="disabled" title="Disabled" />
     </template>


### PR DESCRIPTION
This fixes two type errors:

- In `DropdownButton.vue`, `ComputedGetter` seems to be the wrong type.
- In `Dropdown.story.vue`, `@ts-expect-error` is working correctly, but it's sensitive to the settings in `tsconfig.json` and was making it difficult for me to add this package to the CI. I think using a cast is preferable here anyway.