### PR TITLE
fix(applet): preserve active component when filtering

### DIFF
--- a/packages/applet/src/modules/components/index.vue
+++ b/packages/applet/src/modules/components/index.vue
@@ -120,12 +120,34 @@ const { expanded: expandedTreeNodes } = createExpandedContext()
 const { expanded: expandedStateNodes } = createExpandedContext('component-state')
 createSelectedContext()
 
+const activeComponentAncestors = computed(() => activeComponentId.value ? getTargetLinkedNodes(treeNodeLinkedList.value, activeComponentId.value).slice(0, -1) : [])
+const isActiveComponentVisible = computed(() => activeComponentAncestors.value.every(id => expandedTreeNodes.value.includes(id)))
+
+function expandActiveComponentAncestors() {
+  if (!isActiveComponentVisible.value) {
+    expandedTreeNodes.value = [...new Set([...expandedTreeNodes.value, ...activeComponentAncestors.value])]
+  }
+}
+
+function ensureActiveComponent() {
+  if (!activeComponentId.value || !flattenedTreeNodesIds.value.includes(activeComponentId.value)) {
+    activeComponentId.value = tree.value?.[0]?.id ?? ''
+    expandedTreeNodes.value = getNodesByDepth(treeNodeLinkedList.value, 1)
+  }
+}
+
 async function getComponentsInspectorTree(filter = '') {
   return rpc.value.getInspectorTree({ inspectorId, filter }).then((data) => {
-    const res = parse(data)
-    tree.value = res
-    activeComponentId.value = tree.value?.[0]?.id
-    expandedTreeNodes.value = getNodesByDepth(treeNodeLinkedList.value, 1)
+    const wasActiveComponentVisible = isActiveComponentVisible.value
+
+    tree.value = parse(data)
+
+    ensureActiveComponent()
+
+    if (wasActiveComponentVisible) {
+      expandActiveComponentAncestors()
+    }
+
     componentTreeLoaded.value = true
   })
 }
@@ -202,10 +224,7 @@ function onInspectorTreeUpdated(_data: string) {
     tree.value = data.rootNodes
   }
 
-  if (!flattenedTreeNodesIds.value.includes(activeComponentId.value)) {
-    activeComponentId.value = tree.value?.[0]?.id
-    expandedTreeNodes.value = getNodesByDepth(treeNodeLinkedList.value, 1)
-  }
+  ensureActiveComponent()
 }
 
 rpc.functions.on(DevToolsMessagingEvents.INSPECTOR_TREE_UPDATED, onInspectorTreeUpdated)
@@ -257,7 +276,7 @@ async function inspectComponentInspector() {
       expandedTreeNodes.value.push(data.id)
     }
 
-    expandedTreeNodes.value = [...new Set([...expandedTreeNodes.value, ...getTargetLinkedNodes(treeNodeLinkedList.value, data.id)])]
+    expandActiveComponentAncestors()
     scrollToActiveTreeNode()
   }
   finally {


### PR DESCRIPTION
Fixes #1062.

When filtering using the `Find components...` input, the selected component gets reset every time there's a re-render in the target application.

I've adjusted the logic to preserve the old selection whenever possible. The selection is only reset if the previously selected component is no longer available. This doesn't just apply to re-renders, it also applies to changing the search value.

There's one specific use case I was particularly keen to improve. If you use the search box to find a component, you can select it and then clear the search value. The selection is now preserved, allowing you to see exactly where that component is in the tree. To get this all working smoothly I also needed to adjust the logic for automatically expanding nodes.

Most of the logic I needed already existed elsewhere in the same file, so I've introduced some helpers to avoid duplicating that logic.