### PR TITLE
move vue and vue-router to external

### DIFF
--- a/packages/devtools-kit/tsdown.config.ts
+++ b/packages/devtools-kit/tsdown.config.ts
@@ -9,5 +9,7 @@ export default defineConfig({
   shims: true,
   hash: false,
   ignoreWatch: ['.turbo'],
-  external: ['vue', 'vue-router'],
+  deps: {
+    neverBundle: ['vue', 'vue-router'],
+  },
 })


### PR DESCRIPTION
## Summary                                                                                                                                       
                                                                                                                                                   
When `@vue/devtools-kit` bundles its type declarations via tsdown, it inlines the types from `vue-router` (a devDependency). This causes vue-router's `declare module 'vue'` augmentations — specifically the `GlobalComponents` interface with `RouterView` and `RouterLink` — to be embedded in `dist/index.d.ts`.                                                                                                                   
                  
This creates type conflicts for any library that also augments `GlobalComponents` with its own `RouterView` or `RouterLink` components (e.g. [@kitbag/router](https://github.com/kitbagjs/router)). TypeScript's declaration merging requires subsequent property declarations to have the same type, so consumers see errors like:                                                                                                                       

> [!CAUTION]
> TS2717: Subsequent property declarations must have the same type. Property 'RouterView' must be of type '...' but here has type '...'
                                                                                                                                                   
The same inlining also causes Vue's `App` type to be duplicated as `App$1`, leading to type mismatches when passing `App` instances to `setupDevtoolsPlugin`.                                                                                                                           
                  
## Fix                                                                                                                                           
                  
Add `external: ['vue', 'vue-router']` to the tsdown config for `@vue/devtools-kit`. This prevents tsdown from inlining their type declarations into the bundled `.d.ts` output, keeping them as external `import(...)` references instead. Both packages are already devDependencies — their types should not be bundled.                                                                                                                     
                  
## Test plan                                                                                                                                     
   
- [ ] Build `@vue/devtools-kit` and verify `dist/index.d.ts` no longer contains vue-router's `GlobalComponents` augmentation                     
- [ ] Verify downstream projects that augment `GlobalComponents` with their own router components no longer get `TS2717` errors