### PR TITLE
fix(overlay): use toggleEnabled instead of enable to allow exiting in…

### DIFF
--- a/packages/overlay/src/App.vue
+++ b/packages/overlay/src/App.vue
@@ -129,7 +129,7 @@ const { getIframe } = useIframe(clientUrl, async () => {
           class="vue-devtools__anchor-btn vue-devtools__panel-content vue-devtools__inspector-button"
           title="Toggle Component Inspector"
           :class="{ active: vueInspectorEnabled }"
-          @click="enableVueInspector"
+          @click="toggleVueInspector"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg" style="height: 1.1em; width: 1.1em; opacity:0.5;"


### PR DESCRIPTION
…spector mode

When using it, I noticed that Escape is the only way to exit. Clicking the button again doesn’t toggle the state, so I think adding a toggle feature would improve the user experience.

tip: I think the inspector button should be highlighted when element selection is active and not highlighted when selection is canceled.This way, the user perception will be much clearer.