### PR TITLE
refactor(applet): fix linting problems with props

### DIFF
--- a/packages/applet/src/components/state/ChildStateViewer.vue
+++ b/packages/applet/src/components/state/ChildStateViewer.vue
@@ -4,7 +4,7 @@ import StateFieldViewer from './StateFieldViewer.vue'
 
 withDefaults(defineProps<{
   data: CustomInspectorState[]
-  depth: number
+  depth?: number
   index: string
   expandedStateId?: string
 }>(), {

--- a/packages/applet/src/components/tree/TreeViewer.vue
+++ b/packages/applet/src/components/tree/TreeViewer.vue
@@ -9,8 +9,8 @@ import { useToggleExpanded } from '~/composables/toggle-expanded'
 
 withDefaults(defineProps<{
   data: ComponentTreeNode[] | InspectorTree[]
-  depth: number
-  withTag: boolean
+  depth?: number
+  withTag?: boolean
 }>(), {
   depth: 0,
   withTag: false,


### PR DESCRIPTION
Linting currently shows 3 warnings:

- https://github.com/vuejs/devtools/actions/runs/23250491530/job/67590858933#step:8:11

```
/home/runner/work/devtools/devtools/packages/applet/src/components/state/ChildStateViewer.vue
Warning:   7:3  warning  Prop "depth" should be optional  vue/no-required-prop-with-default

/home/runner/work/devtools/devtools/packages/applet/src/components/tree/TreeViewer.vue
Warning:   12:3  warning  Prop "depth" should be optional    vue/no-required-prop-with-default
Warning:   13:3  warning  Prop "withTag" should be optional  vue/no-required-prop-with-default
```

This PR addresses those 3 warnings.

The current prop configurations lead to type checking errors in other files, which are also fixed by these changes.