### PR TITLE
fix(extension): load `devtools-background.js` as `type="module"`

### DIFF
--- a/packages/chrome-extension/pages/devtools-background.html
+++ b/packages/chrome-extension/pages/devtools-background.html
@@ -4,6 +4,6 @@
     <title></title>
   </head>
   <body>
-    <script src="../dist/devtools-background.js"></script>
+    <script type="module" src="../dist/devtools-background.js"></script>
   </body>
 </html>

--- a/packages/firefox-extension/devtools-background.html
+++ b/packages/firefox-extension/devtools-background.html
@@ -4,6 +4,6 @@
     <title></title>
   </head>
   <body>
-    <script src="../dist/devtools-background.js"></script>
+    <script type="module" src="../dist/devtools-background.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Since d8e2801191443fbfee15b6741cf68e0f05753146, the file `devtools-background.js` has been built as an ES module, rather than an IIFE.

I'm not really familiar with how extensions work, or what the intent was behind switching to an ES module, but when I try to install a local copy of the extensions they don't work. Adding `type="module"` seems to be sufficient to get them working.