### PR TITLE
refactor(overlay): fix a type error for `rpcServer.functions.on`

### DIFF
--- a/packages/overlay/src/App.vue
+++ b/packages/overlay/src/App.vue
@@ -55,7 +55,7 @@ const vueInspector = ref()
 const vueInspectorEnabled = ref(false)
 
 onDevToolsConnected(() => {
-  const rpcServer = getRpcServer<typeof functions>()
+  const rpcServer = getRpcServer<never, typeof functions>()
   rpcServer.functions.on('toggle-panel', (state = !panelVisible) => {
     togglePanelVisible(undefined, state)
   })


### PR DESCRIPTION
The current code is:

```ts
const rpcServer = getRpcServer<typeof functions>()
rpcServer.functions.on('toggle-panel', (state = !panelVisible) => {
  togglePanelVisible(undefined, state)
})
```

TypeScript reports an error for `rpcServer.functions.on`. The typing for `rpcServer.functions` comes from the second generic parameter of `getRpcServer`, which isn't specified in the line above. I believe `typeof functions` needs to be the second parameter ('local functions'), rather than the first ('remote functions').

I've changed it to `getRpcServer<never, typeof functions>()`. I used `never` because we don't use any remote functions in this part of the code.