### PR TITLE
refactor(playground): add types for `Post`

### DIFF
--- a/packages/playground/basic/src/components/types.ts
+++ b/packages/playground/basic/src/components/types.ts
@@ -1,0 +1,6 @@
+export interface Post {
+  userId: number
+  id: number
+  title: string
+  body: string
+}


### PR DESCRIPTION
`Post.vue` and `Posts.vue` both include this line:

```ts
import { Post } from './types'
```

But `./types` doesn't exist. This PR adds it.