### PR TITLE
chore(extensions): fix type errors

### DIFF
--- a/packages/chrome-extension/src/detector.ts
+++ b/packages/chrome-extension/src/detector.ts
@@ -83,3 +83,5 @@ function detect(win: Window) {
 if (document instanceof HTMLDocument) {
   detect(window)
 }
+
+export {}

--- a/packages/chrome-extension/src/devtools-background.ts
+++ b/packages/chrome-extension/src/devtools-background.ts
@@ -34,3 +34,5 @@ function createPanelOnVueDetected() {
     },
   )
 }
+
+export {}

--- a/packages/firefox-extension/src/detector.ts
+++ b/packages/firefox-extension/src/detector.ts
@@ -83,3 +83,5 @@ function detect(win: Window) {
 if (document instanceof HTMLDocument) {
   detect(window)
 }
+
+export {}

--- a/packages/firefox-extension/src/devtools-background.ts
+++ b/packages/firefox-extension/src/devtools-background.ts
@@ -34,3 +34,5 @@ function createPanelOnVueDetected() {
     },
   )
 }
+
+export {}


### PR DESCRIPTION
These 4 files currently report TS errors.

TS is unaware of how these files are being built, so it incorrectly believes that all the code will run in a global scope, leading to collisions between the files. For example, both `devtools-background.ts` files have a variable called `created`, which TS is treating as global and reports an error due to the duplicate declaration.

There are various ways to fix this, but I've just added `export {}` to each file, which tells TS to treat them as ES modules.

This doesn't impact how tsdown builds the files. The built files in `dist` are unchanged.