### PR TITLE
feat: add keyboard shortcut (Alt+Shift+C) to toggle Component Inspector

### DIFF
--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -51,6 +51,12 @@ watch(devtoolsReady, (v) => {
 useEventListener('keydown', (e) => {
   if (e.code === 'KeyD' && e.altKey && e.shiftKey)
     rpc.value.emit('toggle-panel')
+  // Toggle component inspector with Alt(Option) + Shift + C
+  if (e.code === 'KeyC' && e.altKey && e.shiftKey && vueInspectorDetected.value) {
+    e.preventDefault()
+    rpc.value.emit('toggle-panel', false)
+    rpc.value.enableVueInspector()
+  }
 })
 
 watchEffect(() => {

--- a/packages/overlay/src/App.vue
+++ b/packages/overlay/src/App.vue
@@ -83,6 +83,14 @@ addEventListener('keyup', (e) => {
   }
 })
 
+// Toggle component inspector with Alt(Option) + Shift + C
+addEventListener('keydown', (e) => {
+  if (e.code === 'KeyC' && e.altKey && e.shiftKey && vueInspectorSupported.value) {
+    e.preventDefault()
+    toggleVueInspector()
+  }
+})
+
 const vueInspectorSupported = computed(() => {
   return !!(devtools.ctx.state.vitePluginDetected && vueInspector.value)
 })

--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -129,6 +129,10 @@ export default function VitePluginVueDevTools(options?: VitePluginVueDevToolsOpt
         console.log(`  ${green('➜')}  ${bold('Vue DevTools')}: ${green(`Open ${colorUrl(`${devtoolsUrl}`)} as a separate window`)}`)
       }
       console.log(`  ${green('➜')}  ${bold('Vue DevTools')}: ${green(`Press ${yellow(keys)} in App to toggle the Vue DevTools`)}`)
+      if (pluginOptions.componentInspector) {
+        const inspectorKeys = normalizeComboKeyPrint('option-shift-c')
+        console.log(`  ${green('➜')}  ${bold('Vue DevTools')}: ${green(`Press ${yellow(inspectorKeys)} in App to toggle the Component Inspector`)}`)
+      }
     }
   }
 


### PR DESCRIPTION
## Description

Closes vuejs/devtools#1058

This PR adds a keyboard shortcut `Alt(Option)+Shift+C` to toggle the Component Inspector, solving the pain point where clicking to activate the inspector causes pop-ups/overlays to close.

## Motivation

Many UI libraries auto-close pop-ups on outside click. When using the Component Inspector to locate components inside these pop-ups, clicking activates the inspector but simultaneously closes the pop-up. A keyboard shortcut avoids this issue entirely.

## Changes

| File | Change |
|------|--------|
| `packages/overlay/src/App.vue` | Add `Alt+Shift+C` keydown listener to call `toggleVueInspector()` |
| `packages/client/src/App.vue` | Add the same shortcut in client iframe, triggering inspector via RPC |
| `packages/vite/src/vite.ts` | Print shortcut hint in terminal when Vite dev server starts |

## How it works

- The shortcut follows the same pattern as the existing `Alt+Shift+D` (toggle DevTools panel)
- `Alt` maps to `Option` on macOS automatically (via `e.altKey`)
- The shortcut only activates when `vueInspectorSupported` / `vueInspectorDetected` is true
- `Escape` still works to exit the inspector (unchanged)

## Terminal output
<img width="737" height="106" alt="image" src="https://github.com/user-attachments/assets/2e035695-9c15-4ad9-9871-8e7e3db2f9dc" />

## Test
<img width="1728" height="625" alt="image" src="https://github.com/user-attachments/assets/7eeeb8b6-aa5b-4563-a1e5-ccd5d5e5c6c8" />

## Note

The issue author also mentioned customizable shortcuts. Since all existing shortcuts in the project (`Alt+Shift+D`, `Escape`) are hardcoded, adding customization would require architectural changes (e.g. passing user config through virtual modules to runtime). This can be addressed in a follow-up PR if needed.