### PR TITLE
feat: add keyboard shortcut (Alt+Shift+C) to toggle Component Inspector

### DIFF
--- a/packages/client/src/App.vue
+++ b/packages/client/src/App.vue
@@ -51,6 +51,10 @@ watch(devtoolsReady, (v) => {
 useEventListener('keydown', (e) => {
   if (e.code === 'KeyD' && e.altKey && e.shiftKey)
     rpc.value.emit('toggle-panel')
+  if (e.code === 'KeyC' && e.altKey && e.shiftKey && vueInspectorDetected.value) {
+    rpc.value.emit('toggle-panel', false)
+    rpc.value.enableVueInspector()
+  }
 })
 
 watchEffect(() => {

--- a/packages/overlay/src/App.vue
+++ b/packages/overlay/src/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { functions, getDevToolsClientUrl } from '@vue/devtools-core'
 import { devtools, getRpcServer, onDevToolsConnected, setIframeServerContext } from '@vue/devtools-kit'
-import { target } from '@vue/devtools-shared'
+import { isMacOS, target } from '@vue/devtools-shared'
 import { useDevToolsColorMode } from '@vue/devtools-ui'
 import { computed, ref } from 'vue'
 import FrameBox from '~/components/FrameBox.vue'
@@ -83,6 +83,12 @@ addEventListener('keyup', (e) => {
   }
 })
 
+addEventListener('keydown', (e) => {
+  if (e.code === 'KeyC' && e.altKey && e.shiftKey && vueInspectorSupported.value) {
+    toggleVueInspector()
+  }
+})
+
 const vueInspectorSupported = computed(() => {
   return !!(devtools.ctx.state.vitePluginDetected && vueInspector.value)
 })
@@ -117,7 +123,7 @@ const { getIframe } = useIframe(clientUrl, async () => {
     <!-- panel -->
     <div ref="panelEle" class="vue-devtools__panel" :style="panelStyle" @pointerdown="onPointerDown">
       <div
-        class="vue-devtools__anchor-btn panel-entry-btn" title="Toggle Vue DevTools" aria-label="Toggle devtools panel"
+        class="vue-devtools__anchor-btn panel-entry-btn" :title="`Toggle Vue DevTools (${isMacOS() ? '⌥' : 'Alt'}+Shift+D)`" aria-label="Toggle devtools panel"
         :style="panelVisible ? '' : 'filter:saturate(0)'" @click="togglePanelVisible"
       >
         <svg viewBox="0 0 256 198" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -130,7 +136,7 @@ const { getIframe } = useIframe(clientUrl, async () => {
         <div class="vue-devtools__panel-content vue-devtools__panel-divider" />
         <div
           class="vue-devtools__anchor-btn vue-devtools__panel-content vue-devtools__inspector-button"
-          title="Toggle Component Inspector"
+          :title="`Toggle Component Inspector (${isMacOS() ? '⌥' : 'Alt'}+Shift+C)`"
           :class="{ active: vueInspectorEnabled }"
           @click="toggleVueInspector"
         >


### PR DESCRIPTION
## Description

Closes vuejs/devtools#1058

This PR adds a keyboard shortcut `Alt(Option)+Shift+C` to toggle the Component Inspector, solving the pain point where clicking to activate the inspector causes pop-ups/overlays to close.

## Motivation

Many UI libraries auto-close pop-ups on outside click. When using the Component Inspector to locate components inside these pop-ups, clicking activates the inspector but simultaneously closes the pop-up. A keyboard shortcut avoids this issue entirely.

## Changes

| File | Change |
|------|--------|
| `packages/overlay/src/App.vue` | Add `Alt+Shift+C` keydown listener to call `toggleVueInspector()` |
| `packages/client/src/App.vue` | Add the same shortcut in client iframe, triggering inspector via RPC |
| `packages/vite/src/vite.ts` | Print shortcut hint in terminal when Vite dev server starts |

## How it works

- The shortcut follows the same pattern as the existing `Alt+Shift+D` (toggle DevTools panel)
- `Alt` maps to `Option` on macOS automatically (via `e.altKey`)
- The shortcut only activates when `vueInspectorSupported` / `vueInspectorDetected` is true
- `Escape` still works to exit the inspector (unchanged)

## Terminal output
<img width="737" height="106" alt="image" src="https://github.com/user-attachments/assets/2e035695-9c15-4ad9-9871-8e7e3db2f9dc" />

## Test
<img width="1728" height="625" alt="image" src="https://github.com/user-attachments/assets/7eeeb8b6-aa5b-4563-a1e5-ccd5d5e5c6c8" />

## Note

The issue author also mentioned customizable shortcuts. Since all existing shortcuts in the project (`Alt+Shift+D`, `Escape`) are hardcoded, adding customization would require architectural changes (e.g. passing user config through virtual modules to runtime). This can be addressed in a follow-up PR if needed.