### PR TITLE
fix(devtools-kit): remove special handling for Router object

### DIFF
--- a/packages/devtools-kit/src/core/component/state/custom.ts
+++ b/packages/devtools-kit/src/core/component/state/custom.ts
@@ -140,22 +140,6 @@ export function getStoreDetails(store) {
   }
 }
 
-export function getRouterDetails(router) {
-  return {
-    _custom: {
-      type: 'router',
-      displayText: 'VueRouter',
-      value: {
-        options: router.options,
-        currentRoute: router.currentRoute,
-      },
-      fields: {
-        abstract: true,
-      },
-    },
-  }
-}
-
 // @TODO: fix circular dependency
 export function getInstanceDetails(instance) {
   if (instance._)

--- a/packages/devtools-kit/src/core/component/state/replacer.ts
+++ b/packages/devtools-kit/src/core/component/state/replacer.ts
@@ -1,6 +1,6 @@
 import { ensurePropertyExists } from '../utils'
 import { INFINITY, MAX_ARRAY_SIZE, MAX_STRING_SIZE, NAN, NEGATIVE_INFINITY, UNDEFINED } from './constants'
-import { getBigIntDetails, getComponentDefinitionDetails, getDateDetails, getFunctionDetails, getHTMLElementDetails, getInstanceDetails, getMapDetails, getObjectDetails, getRouterDetails, getSetDetails, getStoreDetails } from './custom'
+import { getBigIntDetails, getComponentDefinitionDetails, getDateDetails, getFunctionDetails, getHTMLElementDetails, getInstanceDetails, getMapDetails, getObjectDetails, getSetDetails, getStoreDetails } from './custom'
 import { isVueInstance } from './is'
 import { sanitize } from './util'
 
@@ -73,9 +73,6 @@ export function stringifyReplacer(key: string | number, _value: any, depth?: num
     else if (ensurePropertyExists(val, 'state', true) && ensurePropertyExists(val, '_vm', true)) {
       return getStoreDetails(val)
     }
-    else if (val.constructor && val.constructor.name === 'VueRouter') {
-      return getRouterDetails(val)
-    }
     else if (isVueInstance(val as Record<string, unknown>)) {
       const componentVal = getInstanceDetails(val)
       const parentInstanceDepth = seenInstance?.get(val)
@@ -97,9 +94,6 @@ export function stringifyReplacer(key: string | number, _value: any, depth?: num
     }
     else if (val.constructor?.name === 'Store' && '_wrappedGetters' in val) {
       return '[object Store]'
-    }
-    else if (ensurePropertyExists(val, 'currentRoute', true)) {
-      return '[object Router]'
     }
     const customDetails = getObjectDetails(val)
     if (customDetails != null)

--- a/packages/devtools-kit/src/core/component/types/custom.ts
+++ b/packages/devtools-kit/src/core/component/types/custom.ts
@@ -1,1 +1,1 @@
-export type customTypeEnums = 'function' | 'bigint' | 'map' | 'set' | 'store' | 'router' | 'component' | 'component-definition' | 'HTMLElement' | 'component-definition' | 'date'
+export type customTypeEnums = 'function' | 'bigint' | 'map' | 'set' | 'store' | 'component' | 'component-definition' | 'HTMLElement' | 'component-definition' | 'date'

--- a/packages/devtools-kit/src/types/component.ts
+++ b/packages/devtools-kit/src/types/component.ts
@@ -21,7 +21,7 @@ export interface ComponentTreeNode {
   file?: string
 }
 
-type ComponentBuiltinCustomStateTypes = 'function' | 'map' | 'set' | 'reference' | 'component' | 'component-definition' | 'router' | 'store'
+type ComponentBuiltinCustomStateTypes = 'function' | 'map' | 'set' | 'reference' | 'component' | 'component-definition' | 'store'
 
 interface ComponentCustomState extends ComponentStateBase {
   value: CustomState


### PR DESCRIPTION
There's currently some special handling for rendering a Vue Router instance. However...

1. The check for `val.constructor.name === 'VueRouter'` is for the Vue 2 router, so it doesn't do anything with Vue 3. The code involving `getRouterDetails` doesn't actually run.
2. The other relevant code path in `replacer.ts` returns `'[object Router]'`, which isn't very helpful (see **Before** screenshot below).

I had originally intended to fix that second code path to call `getRouterDetails`, which did work, but it then occurred to me that none of this is really necessary. Maybe at some point in the past there were issues displaying the router instance, but just treating it like any other object works fine now.

**Before:**

<img width="156" height="45" alt="image" src="https://github.com/user-attachments/assets/bd3039f7-c1fe-4dd6-b0ab-cde6c367b8eb" />

**After:**

<img width="497" height="521" alt="image" src="https://github.com/user-attachments/assets/87dd1ebe-f75a-4954-8eb6-bff3f62546f0" />
