### PR TITLE
fix(vite): use TrustedScriptURL for overlay injection under Trusted Types CSP

### DIFF
--- a/packages/vite/src/overlay.js
+++ b/packages/vite/src/overlay.js
@@ -41,7 +41,20 @@ link.href = `${overlayDir}/devtools-overlay.css`
 
 // create script
 const script = document.createElement('script')
-script.src = `${overlayDir}/devtools-overlay.mjs`
+const scriptUrl = `${overlayDir}/devtools-overlay.mjs`
+// Under a `require-trusted-types-for 'script'` CSP, assigning a string to
+// `script.src` is blocked. Wrap the URL in a TrustedScriptURL via a named
+// policy so apps can opt-in by allowing `vue-devtools` in their CSP's
+// `trusted-types` directive.
+if (typeof window !== 'undefined' && window.trustedTypes && typeof window.trustedTypes.createPolicy === 'function') {
+  const policy = window.trustedTypes.createPolicy('vue-devtools', {
+    createScriptURL: input => input,
+  })
+  script.src = policy.createScriptURL(scriptUrl)
+}
+else {
+  script.src = scriptUrl
+}
 script.type = 'module'
 
 // append to head


### PR DESCRIPTION
## Summary

Fixes #1086.

When an app enforces `require-trusted-types-for 'script'` via CSP, the Vite plugin's overlay injection crashes on load:

```
virtual:vue-devtools-path:overlay.js:44 Uncaught TypeError:
Failed to set the 'src' property on 'HTMLScriptElement':
This document requires 'TrustedScriptURL' assignment.
```

`script.src` is a Trusted Types sink, so assigning a plain string is blocked. A default trusted-types policy in the consuming app does not help here, because the overlay script is injected via `injectTo: 'head-prepend'` and runs before the app's entry module (and its policy registration) executes.

## Change

In `packages/vite/src/overlay.js`, wrap the overlay URL in a `TrustedScriptURL` via a named `vue-devtools` policy when `window.trustedTypes` is available; fall back to the plain string otherwise.

```js
if (typeof window !== 'undefined' && window.trustedTypes && typeof window.trustedTypes.createPolicy === 'function') {
  const policy = window.trustedTypes.createPolicy('vue-devtools', {
    createScriptURL: input => input,
  })
  script.src = policy.createScriptURL(scriptUrl)
}
else {
  script.src = scriptUrl
}
```

No behavior change for apps without Trusted Types. Apps that enforce `require-trusted-types-for 'script'` need to add `vue-devtools` to their `trusted-types` directive, e.g.:

```html
<meta http-equiv="Content-Security-Policy"
      content="require-trusted-types-for 'script'; trusted-types default dompurify vue vue-devtools;">
```

## Test plan

- [x] App without Trusted Types CSP: overlay still loads (fallback path).
- [x] App with `require-trusted-types-for 'script'` and `vue-devtools` in the `trusted-types` allowlist: overlay loads, no `TrustedScriptURL` exception.
- [ ] App with `require-trusted-types-for 'script'` but `vue-devtools` not allowlisted: browser surfaces a clear policy-creation error (expected — user fix is to add it to CSP).