### PR TITLE
fix(vite): add missing peer dependency on vue

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -45,7 +45,8 @@
     "stub": "tsdown --watch"
   },
   "peerDependencies": {
-    "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+    "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+    "vue": "^3.0.0"
   },
   "dependencies": {
     "@vue/devtools-core": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -948,6 +948,9 @@ importers:
       vite-plugin-vue-inspector:
         specifier: ^6.0.0
         version: 6.0.0(vite@7.1.10(@types/node@24.7.2)(jiti@2.5.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1))
+      vue:
+        specifier: ^3.0.0
+        version: 3.5.22(typescript@5.9.3)
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
`vite-plugin-vue-devtools` has a dependency on `@vue/devtools-core` which peer-depends on `vue`, but `vite-plugin-vue-devtools` declares neither a dependency nor a peer-dependency on `vue`

This PR adds `vue` as a peer-dependency of `vite-plugin-vue-devtools`