### PR TITLE
fix: guard openInEditor when inspector is unavailable

### DIFF
--- a/packages/devtools-kit/src/core/open-in-editor/index.ts
+++ b/packages/devtools-kit/src/core/open-in-editor/index.ts
@@ -29,7 +29,12 @@ export function openInEditor(options: OpenInEditorOptions = {}) {
     }
     else if (devtoolsState.vitePluginDetected) {
       const _baseUrl = target.__VUE_DEVTOOLS_OPEN_IN_EDITOR_BASE_URL__ ?? baseUrl
-      target.__VUE_INSPECTOR__.openInEditor(_baseUrl, file, line, column)
+      if (target.__VUE_INSPECTOR__) {
+        target.__VUE_INSPECTOR__.openInEditor(_baseUrl, file, line, column)
+      }
+      else {
+        console.warn('[Vue DevTools] Component inspector is not available. If you have disabled the Options API, the component inspector may not be initialized.')
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

This adds a small guard around the Vite plugin open-in-editor path so DevTools does not throw when the component inspector has not been initialized.

In that state `__VUE_INSPECTOR__` is unavailable, so calling `openInEditor` directly raises a TypeError. With this change, DevTools skips the call and logs a clearer warning instead.

Refs #824