### PR TITLE
fix(client): disable pin reorder buttons at list bounds

### DIFF
--- a/packages/client/src/pages/settings.vue
+++ b/packages/client/src/pages/settings.vue
@@ -125,14 +125,14 @@ const minimizePanelInteractiveLabel = computed(() => {
                   <template v-if="pinnedTabs.includes(tab.name)">
                     <button
                       class="flex items-center px1 py1 text-sm op65 disabled:(cursor-not-allowed op30) not-disabled:hover:(bg-active op100)"
-                      :disabled="pinnedTabs.indexOf(tab.name) === 0"
+                      :disabled="pinnedTabs[0] === tab.name"
                       @click.stop="pinMove(tab.name, -1)"
                     >
                       <div class="i-carbon-caret-up" />
                     </button>
                     <button
                       class="flex items-center px1 py1 text-sm op65 disabled:(cursor-not-allowed op30) not-disabled:hover:(bg-active op100)"
-                      :disabled="pinnedTabs.indexOf(tab.name) === pinnedTabs.length - 1"
+                      :disabled="pinnedTabs[pinnedTabs.length - 1] === tab.name"
                       @click.stop="pinMove(tab.name, 1)"
                     >
                       <div class="i-carbon-caret-down" />

--- a/packages/client/src/pages/settings.vue
+++ b/packages/client/src/pages/settings.vue
@@ -124,20 +124,16 @@ const minimizePanelInteractiveLabel = computed(() => {
                   <div flex-auto />
                   <template v-if="pinnedTabs.includes(tab.name)">
                     <button
-                      class="flex items-center px1 py1 text-sm op65 hover:(bg-active op100)"
-                      @click.stop="() => {
-                        if (pinnedTabs.indexOf(tab.name) === 0) return
-                        pinMove(tab.name, -1)
-                      }"
+                      class="flex items-center px1 py1 text-sm op65 disabled:(cursor-not-allowed op30) not-disabled:hover:(bg-active op100)"
+                      :disabled="pinnedTabs.indexOf(tab.name) === 0"
+                      @click.stop="pinMove(tab.name, -1)"
                     >
                       <div class="i-carbon-caret-up" />
                     </button>
                     <button
-                      class="flex items-center px1 py1 text-sm op65 hover:(bg-active op100)"
-                      @click.stop="() => {
-                        if (pinnedTabs.indexOf(tab.name) === pinnedTabs.length - 1) return
-                        pinMove(tab.name, 1)
-                      }"
+                      class="flex items-center px1 py1 text-sm op65 disabled:(cursor-not-allowed op30) not-disabled:hover:(bg-active op100)"
+                      :disabled="pinnedTabs.indexOf(tab.name) === pinnedTabs.length - 1"
+                      @click.stop="pinMove(tab.name, 1)"
                     >
                       <div class="i-carbon-caret-down" />
                     </button>


### PR DESCRIPTION
now:<img width="1007" height="406" alt="屏幕截图_8-6-2026_20280_localhost" src="https://github.com/user-attachments/assets/07ae1013-a28c-4217-bb18-cc5381ef74d6" />

before:<img width="847" height="311" alt="屏幕截图_8-6-2026_20499_localhost" src="https://github.com/user-attachments/assets/1fad03e6-95ca-4179-bd92-4034eadad18a" />
