### PR TITLE
fix(vite): point module field to emitted ESM file

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -28,7 +28,7 @@
     "./*": "./*"
   },
   "main": "dist/vite.cjs",
-  "module": "dist/vite.mjs",
+  "module": "dist/vite.js",
   "files": [
     "*.d.ts",
     "./src/overlay.js",


### PR DESCRIPTION
## Summary

`vite-plugin-vue-devtools` currently advertises `module: dist/vite.mjs` in `packages/vite/package.json`, but the package build emits `dist/vite.js` and `dist/vite.cjs`. The published npm tarball also contains `dist/vite.js`, not `dist/vite.mjs`.

This updates the `module` field to point at the emitted ESM file, matching the existing `exports[.].import` entry.

## Validation

- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm run build:vite`
- `corepack pnpm --filter vite-plugin-vue-devtools pack --pack-destination $env:TEMP`
- Installed the packed tarball in a clean temp project and confirmed `pkg.module === dist/vite.js` and that the referenced file exists.