### PR TITLE
fix(vite): align module field with ESM output

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -28,7 +28,7 @@
     "./*": "./*"
   },
   "main": "dist/vite.cjs",
-  "module": "dist/vite.mjs",
+  "module": "dist/vite.js",
   "files": [
     "*.d.ts",
     "./src/overlay.js",


### PR DESCRIPTION
## Summary

`vite-plugin-vue-devtools@8.1.2` publishes `dist/vite.js`, `dist/vite.cjs`, and the corresponding declaration files, but its legacy `module` field still points to `dist/vite.mjs`.

That file is not present in the npm tarball. The package `exports["."].import` entry already points to the existing ESM output at `./dist/vite.js`, so this PR aligns the legacy `module` field with the actual published ESM artifact.

## Validation

- `npm view vite-plugin-vue-devtools@8.1.2 module exports --json` shows `module: "dist/vite.mjs"` while `exports["."].import` uses `./dist/vite.js`.
- `npm pack vite-plugin-vue-devtools@8.1.2 --dry-run --json` confirms `dist/vite.js` is present and `dist/vite.mjs` is absent.
- `node -e "const p=require('./packages/vite/package.json'); if (p.module !== 'dist/vite.js') throw new Error(p.module); if (p.exports['.'].import !== './dist/vite.js') throw new Error(p.exports['.'].import); console.log(JSON.stringify({module:p.module, import:p.exports['.'].import}))"`
- `git diff --check`

I attempted `pnpm install --frozen-lockfile --ignore-scripts --filter vite-plugin-vue-devtools...`, but dependency installation did not complete within 5 minutes in this environment. This change is limited to package metadata and matches the existing build output named by the package exports map.