### PR TITLE
fix(kit,shared): mark packages side-effect-free for treeshaking

### DIFF
--- a/packages/devtools-kit/package.json
+++ b/packages/devtools-kit/package.json
@@ -9,6 +9,7 @@
     "type": "git",
     "url": "git+https://github.com/vuejs/devtools.git"
   },
+  "sideEffects": false,
   "exports": {
     ".": {
       "import": "./dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,6 +9,7 @@
     "type": "git",
     "url": "git+https://github.com/vuejs/devtools.git"
   },
+  "sideEffects": false,
   "exports": {
     ".": {
       "import": "./dist/index.js",


### PR DESCRIPTION
follow-on from #795, this applies `sideEffects: false` for two other packages.

noticed this in a bundle-size increase when migrating to vite 8 in https://github.com/nuxt/nuxt/pull/35439.