### PR TITLE
refactor(kit): processInject

### DIFF
--- a/packages/devtools-kit/src/core/component/state/process.ts
+++ b/packages/devtools-kit/src/core/component/state/process.ts
@@ -231,11 +231,16 @@ function processProvide(instance: VueAppInstance) {
     }))
 }
 
+const hasOwnProperty = Object.prototype.hasOwnProperty
+const hasOwn = (
+  val: object,
+  key: string | symbol,
+): key is keyof typeof val => hasOwnProperty.call(val, key)
+
 function processInject(instance: VueAppInstance, mergedType: Record<string, unknown>) {
   if (!mergedType?.inject)
     return []
-  let keys: any[] = []
-  let defaultValue
+  let keys: any[]
   if (Array.isArray(mergedType.inject)) {
     keys = mergedType.inject.map(key => ({
       key,
@@ -250,8 +255,7 @@ function processInject(instance: VueAppInstance, mergedType: Record<string, unkn
         originalKey = value
       }
       else {
-        originalKey = value.from
-        defaultValue = value.default
+        originalKey = value.from ?? key
       }
       return {
         key,
@@ -261,9 +265,8 @@ function processInject(instance: VueAppInstance, mergedType: Record<string, unkn
   }
   return keys.map(({ key, originalKey }) => ({
     type: 'injected',
-    key: originalKey && key !== originalKey ? `${originalKey.toString()} ➞ ${key.toString()}` : key.toString(),
-    // eslint-disable-next-line no-prototype-builtins
-    value: returnError(() => instance.ctx.hasOwnProperty(key) ? instance.ctx[key] : instance.provides.hasOwnProperty(originalKey) ? instance.provides[originalKey] : defaultValue),
+    key: key !== originalKey ? `${String(originalKey)} ➞ ${String(key)}` : String(key),
+    value: returnError(() => hasOwn(instance.ctx, key) ? instance.ctx[key] : undefined),
   }))
 }
 


### PR DESCRIPTION
There were a few things about `processInject` that caught my eye, which I've attempted to address here.

```ts
// eslint-disable-next-line no-prototype-builtins
value: returnError(() => instance.ctx.hasOwnProperty(key) ? instance.ctx[key] : instance.provides.hasOwnProperty(originalKey) ? instance.provides[originalKey] : defaultValue),
```

`instance.provides` uses `Object.create(null)`, so accessing `instance.provides.hasOwnProperty` will throw an error. In practice, it's quite difficult to hit that error, and the error is caught by `returnError`, but nevertheless, `instance.provides.hasOwnProperty` will never succeed.

Due to that error, the `defaultValue` is never actually used. However, even if it were used, there are some problems with that value. The logic for setting `defaultValue` leads to it being shared between all injections, so if multiple injections attempt to set a `default` it will just use the final value as the value for all injections. It also doesn't account for when the `default` is a factory function. In practice, we can just remove all the code related to `default`. Vue will set the default on `instance.ctx`, so we don't need any special handling for it in the devtools.

I made this change to ensure `originalKey` is always set:

```diff
- originalKey = value.from
+ originalKey = value.from ?? key
```

That allows the later check for `originalKey && key !== originalKey` to be simplified to just `key !== originalKey`.

I've switched a few calls from `x.toString()` to use `String(x)` instead. I think that's generally regarded more idiomatic, handling a wider range of values safely. Vue core uses that pattern extensively. In practice, I don't think it matters in this specific code, but `String(x)` saves us having to worry about edge cases, especially as the values have type `any`.

I've also extracted a separate `hasOwn` function. The code for that function comes from Vue core. Using a separate function like this avoids any of the risks associated with `Object.create(null)`. That function can be moved to a shared location and reused elsewhere, but I thought it'd be better to do that in a separate PR, rather than expanding the scope of this refactoring to other files.

Using `hasOwn` allows the `eslint-disable-next-line` to be removed.

I've retained the call to `returnError`, as that seems to be a pattern used throughout this file, but in practice I don't think the new code will throw any errors.