### PR TITLE
feat(devtools-api): add no-op stub under node export condition

### DIFF
--- a/packages/devtools-api/package.json
+++ b/packages/devtools-api/package.json
@@ -12,6 +12,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
+      "node": {
+        "import": "./dist/index-node.js",
+        "require": "./dist/index-node.cjs"
+      },
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }

--- a/packages/devtools-api/src/index-node.ts
+++ b/packages/devtools-api/src/index-node.ts
@@ -1,0 +1,19 @@
+import type { PluginDescriptor, PluginSetupFunction } from '@vue/devtools-kit'
+
+export function addCustomCommand(): void {}
+export function addCustomTab(): void {}
+export function onDevToolsClientConnected(_fn: () => void): Promise<void> {
+  return new Promise<void>(() => {})
+}
+export function onDevToolsConnected(_fn: () => void): Promise<void> {
+  return new Promise<void>(() => {})
+}
+export function removeCustomCommand(): void {}
+export function setupDevToolsPlugin(_pluginDescriptor: PluginDescriptor, _setupFn: PluginSetupFunction): void {}
+
+export { setupDevToolsPlugin as setupDevtoolsPlugin }
+
+export type {
+  CustomCommand,
+  CustomTab,
+} from '@vue/devtools-kit'

--- a/packages/devtools-api/tsdown.config.ts
+++ b/packages/devtools-api/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsdown'
 
 const baseConfig = defineConfig({
-  entry: 'src/index.ts',
+  entry: ['src/index.ts', 'src/index-node.ts'],
   deps: {
     neverBundle: [
       'vue',
@@ -28,6 +28,7 @@ const cjsConfig = defineConfig({
 
 const iifeConfig = defineConfig({
   ...baseConfig,
+  entry: 'src/index.ts',
   format: 'iife',
   deps: {
     ...baseConfig.deps,
@@ -41,6 +42,7 @@ const iifeConfig = defineConfig({
 
 const esmBrowserConfig = defineConfig({
   ...baseConfig,
+  entry: 'src/index.ts',
   format: 'esm',
   deps: {
     ...baseConfig.deps,


### PR DESCRIPTION
noticed in nuxt that `vue-router` (which imports and calls `setupDevToolsPlugin` under a condition) was pulling in the entire devtools stack _on the server_, including devframe, etc.

one solution is simply to provide a node stub.

> [!NOTE]
> ~~I'm opening this PR as draft in order to test it out and see if this works to solve the tracing of all of these extra dependencies.~~
>
> **update** testing on nuxt, this PR saved us ~213K on a production build e🤯