### PR TITLE
fix(overlay): ARIA attributes for buttons

### DIFF
--- a/packages/overlay/src/App.vue
+++ b/packages/overlay/src/App.vue
@@ -117,8 +117,13 @@ const { getIframe } = useIframe(clientUrl, async () => {
     <!-- panel -->
     <div ref="panelEle" class="vue-devtools__panel" :style="panelStyle" @pointerdown="onPointerDown">
       <div
-        class="vue-devtools__anchor-btn panel-entry-btn" title="Toggle Vue DevTools" aria-label="Toggle devtools panel"
-        :style="panelVisible ? '' : 'filter:saturate(0)'" @click="togglePanelVisible"
+        role="button"
+        class="vue-devtools__anchor-btn panel-entry-btn"
+        title="Toggle Vue DevTools"
+        aria-label="Toggle devtools panel"
+        :aria-pressed="panelVisible"
+        :style="panelVisible ? '' : 'filter:saturate(0)'"
+        @click="togglePanelVisible"
       >
         <svg viewBox="0 0 256 198" fill="none" xmlns="http://www.w3.org/2000/svg">
           <path fill="#41B883" d="M204.8 0H256L128 220.8L0 0h97.92L128 51.2L157.44 0h47.36Z" />
@@ -129,8 +134,11 @@ const { getIframe } = useIframe(clientUrl, async () => {
       <template v-if="vueInspectorSupported">
         <div class="vue-devtools__panel-content vue-devtools__panel-divider" />
         <div
+          role="button"
           class="vue-devtools__anchor-btn vue-devtools__panel-content vue-devtools__inspector-button"
           title="Toggle Component Inspector"
+          aria-label="Toggle component inspector"
+          :aria-pressed="vueInspectorEnabled"
           :class="{ active: vueInspectorEnabled }"
           @click="toggleVueInspector"
         >


### PR DESCRIPTION
Closes #928.

Elements with `aria-label` must also have a suitable `role`. This problem is currently being reported by ARIA testing tools, including the built-in Lighthouse tool in Chrome.

The roles that support `aria-label` are listed at:

- https://www.w3.org/TR/wai-aria/#namefromauthor

I think `role="button"` is the most appropriate for this use case. I'm not sure why these buttons are using `<div>` rather than `<button>` but I haven't changed that.

I've made similar changes to the other button.

I've also added `aria-pressed` as both buttons function as toggle buttons with pressed and unpressed states.