### PR TITLE
refactor(kit): extract shared hasOwn helper

### DIFF
--- a/packages/devtools-kit/src/core/component/state/editor.ts
+++ b/packages/devtools-kit/src/core/component/state/editor.ts
@@ -5,6 +5,7 @@ import { isReactive, isRef, toRaw } from '../../../shared/stub-vue'
 import { EditStatePayload } from '../../../types'
 
 import { getComponentInstance } from '../utils'
+import { hasOwn } from './util'
 
 export type Recordable = Record<PropertyKey, any>
 
@@ -70,7 +71,7 @@ export class StateEditor {
       if (this.refEditor.isRef(object))
         object = this.refEditor.get(object)
     }
-    return object != null && Object.prototype.hasOwnProperty.call(object, sections[0])
+    return object != null && hasOwn(object, sections[0])
   }
 
   createDefaultSetCallback(state: EditStatePayload) {

--- a/packages/devtools-kit/src/core/component/state/process.ts
+++ b/packages/devtools-kit/src/core/component/state/process.ts
@@ -3,7 +3,7 @@ import type { InspectorState } from '../types'
 import { camelize } from '@vue/devtools-shared'
 import { ensurePropertyExists, returnError } from '../utils'
 import { vueBuiltins } from './constants'
-import { escape, getPropType, getSetupStateType, toRaw } from './util'
+import { escape, getPropType, getSetupStateType, hasOwn, toRaw } from './util'
 
 function mergeOptions(
   to: any,
@@ -25,7 +25,7 @@ function mergeOptions(
   )
 
   for (const key of ['computed', 'inject']) {
-    if (Object.prototype.hasOwnProperty.call(from, key)) {
+    if (hasOwn(from, key)) {
       to[key] ??= {}
       Object.assign(to[key], from[key])
     }
@@ -230,12 +230,6 @@ function processProvide(instance: VueAppInstance) {
       value: returnError(() => instance.provides[key]),
     }))
 }
-
-const hasOwnProperty = Object.prototype.hasOwnProperty
-const hasOwn = (
-  val: object,
-  key: string | symbol,
-): key is keyof typeof val => hasOwnProperty.call(val, key)
 
 function processInject(instance: VueAppInstance, mergedType: Record<string, unknown>) {
   if (!mergedType?.inject)

--- a/packages/devtools-kit/src/core/component/state/util.ts
+++ b/packages/devtools-kit/src/core/component/state/util.ts
@@ -102,3 +102,9 @@ export function escape(s: string) {
     return ESC[s] || s
   })
 }
+
+const hasOwnProperty = Object.prototype.hasOwnProperty
+export const hasOwn = (
+  val: object,
+  key: string | symbol,
+): key is keyof typeof val => hasOwnProperty.call(val, key)


### PR DESCRIPTION
Following on from #1112, I've extracted `hasOwn` to a shared helper. This is currently being used in 3 places, all in `core/component/state/`.

This might also be useful in #1110, which currently uses a `hasOwnProperty` check.