### PR TITLE
fix(ui): use accessible close buttons

### DIFF
--- a/packages/ui/src/components/Dialog.vue
+++ b/packages/ui/src/components/Dialog.vue
@@ -77,9 +77,15 @@ onMounted(() => isMount.value = true)
                 {{ props.title }}
               </slot>
             </div>
-            <div v-if="closable" class="h6 w6 $ui-fcc cursor-pointer rounded-full transition-colors hover:bg-primary-100 dark:hover:bg-gray-700" @click="close">
-              <div class="i-carbon-close" />
-            </div>
+            <button
+              v-if="closable"
+              type="button"
+              aria-label="Close dialog"
+              class="h6 w6 $ui-fcc cursor-pointer rounded-full border-none bg-transparent p0 transition-colors hover:bg-primary-100 dark:hover:bg-gray-700"
+              @click="close"
+            >
+              <div class="i-carbon-close" aria-hidden="true" />
+            </button>
           </div>
           <div class="content transition-all transition-duration-300">
             <slot />

--- a/packages/ui/src/components/Drawer.vue
+++ b/packages/ui/src/components/Drawer.vue
@@ -88,7 +88,15 @@ onMounted(() => isMount.value = true)
           class="drawer pointer-events-auto absolute min-w-25 of-auto $ui-border-base transition-transform transition-duration-300"
           @click.stop
         >
-          <div v-if="closable" class="i-carbon-close absolute right-1.5 top-1.5 $ui-z-max cursor-pointer p1 text-lg $ui-text" @click="show = false" />
+          <button
+            v-if="closable"
+            type="button"
+            aria-label="Close drawer"
+            class="absolute right-1.5 top-1.5 $ui-z-max cursor-pointer border-none bg-transparent p1 text-lg $ui-text"
+            @click="show = false"
+          >
+            <div class="i-carbon-close" aria-hidden="true" />
+          </button>
           <slot />
         </div>
       </Overlay>


### PR DESCRIPTION
Fixes #885.

This updates the shared Dialog and Drawer close controls to use native buttons with accessible names. The existing click behavior and visual styling stay the same, but keyboard users and assistive technology now get proper button semantics.

Verification:

- corepack pnpm exec eslint packages/ui/src/components/Dialog.vue packages/ui/src/components/Drawer.vue
- corepack pnpm run build:ui
- git diff --check