### PR TITLE
docs: remove redundant "Developer experience" feature card

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,9 +21,6 @@ hero:
     alt: Vue DevTools
 
 features:
-  - icon: ⚡️
-    title: Developer experience
-    details: Enhance your Vue development journey with an amazing experience!
   - icon: 🎛
     title: Extensive App
     details: Vite Plugin, Browser Extension, Standalone App, There always one for you.


### PR DESCRIPTION
Fixes #1119.

The "Developer experience" feature card repeats the hero tagline word for word ("Enhance your Vue development journey with an amazing experience!"), so it only restates what is already at the top of the page. This removes that card.