### PR TITLE
fix(vite): simplify shortcut console output

### DIFF
--- a/packages/vite/src/vite.ts
+++ b/packages/vite/src/vite.ts
@@ -20,12 +20,12 @@ function getVueDevtoolsPath() {
 }
 
 const toggleComboKeysMap = {
-  option: process.platform === 'darwin' ? 'Option(⌥)' : 'Alt(⌥)',
-  meta: 'Command(⌘)',
-  shift: 'Shift(⇧)',
+  option: process.platform === 'darwin' ? 'Option' : 'Alt',
+  meta: 'Command',
+  shift: 'Shift',
 }
 function normalizeComboKeyPrint(toggleComboKey: string) {
-  return toggleComboKey.split('-').map(key => toggleComboKeysMap[key] || key[0].toUpperCase() + key.slice(1)).join(dim('+'))
+  return toggleComboKey.split('-').map(key => toggleComboKeysMap[key] || key[0].toUpperCase() + key.slice(1)).join(dim(' + '))
 }
 
 const devtoolsNextResourceSymbol = '?__vue-devtools-next-resource'


### PR DESCRIPTION
## Summary

- remove modifier-key symbols from the Vite startup message
- preserve platform-specific `Option` and `Alt` labels
- add spaces around shortcut separators for improved terminal readability

The shortcut is now displayed as `Option + Shift + D` on macOS and `Alt + Shift + D` on other platforms.

Closes #1017

## Validation

- `pnpm exec eslint packages/vite/src/vite.ts`
- `pnpm --filter vite-plugin-vue-devtools build`
- `pnpm type-check`
- `pnpm test --run` — 85 tests passed