### PR TITLE
fix(applet): use monospace font in node tags

### DIFF
--- a/packages/applet/src/components/basic/NodeTag.vue
+++ b/packages/applet/src/components/basic/NodeTag.vue
@@ -18,7 +18,7 @@ defineProps<{
       color: `#${toHex(tag.textColor)}`,
       backgroundColor: `#${toHex(tag.backgroundColor)}`,
     }"
-    class="ml-2 rounded-sm px-1 text-[0.75rem] leading-snug"
+    class="font-state-field ml-2 rounded-sm px-1 text-[0.75rem] leading-snug"
   >
     {{ tag.label }}
   </span>


### PR DESCRIPTION
Node tags inherit the sans font, so a `0` and an `O` inside a tag label are hard to tell apart. The node label right next to them already uses `font-state-field` (Roboto Mono), where the zero carries a dot, so this applies the same class to the tag.

Fixes #1124