### PR TITLE
fix(client): avoid toggling panel in extension inspect flow

### DIFF
--- a/packages/client/src/pages/components.vue
+++ b/packages/client/src/pages/components.vue
@@ -1,14 +1,21 @@
 <script setup lang="ts">
 import { Components as ComponentsPanel } from '@vue/devtools-applet'
 import { rpc } from '@vue/devtools-core'
+import { isInChromePanel } from '@vue/devtools-shared'
 import { openInEditor } from '../composables/open-in-editor'
 import '@vue/devtools-applet/style.css'
 
 function onInspectComponentStart() {
+  if (isInChromePanel)
+    return
+
   rpc.value.emit('toggle-panel', false)
 }
 
 function onInspectComponentEnd() {
+  if (isInChromePanel)
+    return
+
   rpc.value.emit('toggle-panel', true)
 }
 </script>


### PR DESCRIPTION
### Description

When using browser extension DevTools, starting the component inspector from the panel also toggles the Vite overlay panel on the page, so the two inspectors interfere with each other (#1004).

The client's component inspect handlers unconditionally emit the `toggle-panel` RPC. That RPC exists to minimize the overlay while inspecting a component (#119), which only makes sense when the devtools UI lives on the page — not when triggered from a separate extension panel.

This PR skips the emit when running in a browser extension panel, using the existing `isInChromePanel` env flag:

- **Extension panels**: emit skipped — no more unexpected overlay toggling
- **In-page devtools (Vite overlay)**: unchanged — minimize-on-inspect still works

fixes #1004

### Validation

- [x] `pnpm lint`
- [x] `pnpm type-check`
- [x] `pnpm test` (85/85)
- [x] Manually verified in Chrome: inspecting from the extension panel no longer opens the Vite overlay

https://github.com/user-attachments/assets/33382e92-d8c4-45a5-9fa5-c152ec3f174d
